### PR TITLE
Support num_agents=1 under quad_multi env

### DIFF
--- a/envs/quadrotors/quad_utils.py
+++ b/envs/quadrotors/quad_utils.py
@@ -84,7 +84,7 @@ def make_quadrotor_env_multi(cfg, **kwargs):
     if cfg.quads_settle_reward is not None:
         reward_shaping['quad_rewards']['quadsettle'] = cfg.quads_settle_reward
 
-    env = QuadsRewardShapingWrapper(env, reward_shaping_scheme=reward_shaping)
+    env = QuadsRewardShapingWrapper(env, reward_shaping_scheme=reward_shaping, is_multiagent=True)
 
     return env
 

--- a/envs/quadrotors/wrappers/reward_shaping.py
+++ b/envs/quadrotors/wrappers/reward_shaping.py
@@ -11,7 +11,7 @@ DEFAULT_QUAD_REWARD_SHAPING = dict(
 
 
 class QuadsRewardShapingWrapper(gym.Wrapper, RewardShapingInterface):
-    def __init__(self, env, reward_shaping_scheme=None):
+    def __init__(self, env, reward_shaping_scheme=None, is_multiagent=False):
         gym.Wrapper.__init__(self, env)
         RewardShapingInterface.__init__(self)
 
@@ -20,6 +20,7 @@ class QuadsRewardShapingWrapper(gym.Wrapper, RewardShapingInterface):
         self.episode_actions = None
 
         self.num_agents = env.num_agents if hasattr(env, 'num_agents') else 1
+        self.is_multiagent = is_multiagent
 
         # save a reference to this wrapper in the actual env class, for other wrappers and for outside access
         self.env.unwrapped.reward_shaping_interface = self
@@ -48,10 +49,10 @@ class QuadsRewardShapingWrapper(gym.Wrapper, RewardShapingInterface):
             env_reward_shaping[key] = weight
 
         obs, rewards, dones, infos = self.env.step(action)
-        if self.num_agents == 1:
-            infos_multi, dones_multi = [infos], [dones]
-        else:
+        if self.is_multiagent:
             infos_multi, dones_multi = infos, dones
+        else:
+            infos_multi, dones_multi = [infos], [dones]
 
         for i, info in enumerate(infos_multi):
             rew_dict = info['rewards']


### PR DESCRIPTION
For supporting num_agents=1 under quad_multi env, we don't have to use MultiAgentWrapper, since we already wrap the obs, rew, done, info in multi_quad env, and the simplest way is setting variable is_multiagent=1 under quad_multi env.