### PR TITLE
Use numpy for shared buffers

### DIFF
--- a/sample_factory/algorithms/appo/appo_utils.py
+++ b/sample_factory/algorithms/appo/appo_utils.py
@@ -198,7 +198,7 @@ class TensorBatcher:
             log.info('Allocating new CPU tensor batch (could not get from the pool)')
 
             for d1, cache_d, key, tensor_arr, _ in iter_dicts_recursively(dict_of_tensor_arrays, tensor_batch):
-                cache_d[key] = torch.cat(tensor_arr, dim=0)
+                cache_d[key] = torch.from_numpy(np.concatenate(tensor_arr, axis=0))
                 if use_pinned_memory:
                     cache_d[key] = cache_d[key].pin_memory()
         else:
@@ -207,7 +207,7 @@ class TensorBatcher:
                     offset = 0
                     for t in tensor_arr:
                         first_dim = t.shape[0]
-                        cache_t[offset:offset + first_dim].copy_(t)
+                        cache_t[offset:offset + first_dim].copy_(torch.as_tensor(t))
                         offset += first_dim
 
         return tensor_batch

--- a/sample_factory/algorithms/appo/learner.py
+++ b/sample_factory/algorithms/appo/learner.py
@@ -204,7 +204,7 @@ class LearnerWorker:
         self.obs_space = obs_space
         self.action_space = action_space
 
-        self.rollout_tensors = shared_buffers.tensor_trajectories
+        self.rollout_tensors = shared_buffers.tensors
         self.traj_tensors_available = shared_buffers.is_traj_tensor_available
         self.policy_versions = shared_buffers.policy_versions
         self.stop_experience_collection = shared_buffers.stop_experience_collection
@@ -332,7 +332,7 @@ class LearnerWorker:
 
     def _mark_rollout_buffer_free(self, rollout):
         r = rollout
-        self.traj_tensors_available[r.worker_idx, r.split_idx][r.env_idx, r.agent_idx, r.traj_buffer_idx] = 1
+        self.traj_tensors_available[r.worker_idx, r.split_idx, r.env_idx, r.agent_idx, r.traj_buffer_idx] = 1
 
     def _prepare_train_buffer(self, rollouts, macro_batch_size, timing):
         trajectories = [AttrDict(r['t']) for r in rollouts]


### PR DESCRIPTION
Use numpy arrays that point to shared memory directly.  This makes everything a bit faster.

Before
```
[2021-04-24 19:49:53,259][18793] Env runner 1, CPU aff. [40, 41, 42, 43, 12, 13, 14, 15, 16, 17, 44, 45], rollouts 5340: timing wait_actor: 0.0000, waiting: 13.1354, reset: 3.6658, save_policy_outputs: 6.2761, env_step: 10.9072, overhead: 4.2518, prepare_next_step: 8.6321, complete_rollouts: 0.0205, enqueue_policy_requests: 0.2370, one_step: 0.0125, work: 30.8622
[2021-04-24 19:49:53,260][18792] Env runner 0, CPU aff. [40, 41, 42, 43, 12, 13, 14, 15, 16, 17, 44, 45], rollouts 5460: timing wait_actor: 0.0000, waiting: 13.0427, reset: 3.0303, save_policy_outputs: 6.3372, env_step: 10.7908, overhead: 4.3189, prepare_next_step: 8.6882, complete_rollouts: 0.0202, enqueue_policy_requests: 0.2517, one_step: 0.0136, work: 30.9525
[2021-04-24 19:49:53,363][18790] Policy worker avg. requests 2.34, timing: init: 4.6151, wait_policy_total: 3.3299, wait_policy: 0.0031, handle_policy_step: 36.9214, one_step: 0.0051, deserialize: 0.9906, stack: 7.0830, obs_to_device: 7.1616, forward: 8.1910, to_cpu: 8.6954, format_outputs: 0.8410, postprocess: 3.6305, weight_update: 0.0009
[2021-04-24 19:49:53,381][18791] Policy worker avg. requests 2.48, timing: init: 4.7834, wait_policy_total: 3.1026, wait_policy: 0.0051, handle_policy_step: 36.9025, one_step: 0.0000, deserialize: 0.9929, stack: 7.0605, obs_to_device: 7.2252, forward: 8.1452, to_cpu: 8.7483, format_outputs: 0.8395, postprocess: 3.5618, weight_update: 0.0008
[2021-04-24 19:49:53,482][18773] GPU learner timing: extract: 0.2872, buffers: 0.1268, batching: 11.3400, buff_ready: 0.4710, tensors_gpu_float: 5.6646, squeeze: 0.0058, prepare: 17.6961, batcher_mem: 11.1063
[2021-04-24 19:49:53,788][18773] Train loop timing: init: 2.9056, train_wait: 0.3395, epoch_init: 0.0012, minibatch_init: 0.0006, forward_head: 0.3543, bptt_initial: 5.2838, bptt_forward_core: 0.5320, bptt: 0.5412, tail: 0.5661, vtrace: 0.8797, losses: 0.7290, clip: 9.9975, update: 12.8597, after_optimizer: 2.4539, train: 24.3433
[2021-04-24 19:49:54,232][18744] Workers joined!
[2021-04-24 19:49:54,233][18744] Collected {0: 1040384}, FPS: 24777.7
```

After:
```
[2021-04-24 19:45:16,798][10024] Env runner 0, CPU aff. [40, 41, 42, 43, 12, 13, 14, 15, 16, 17, 44, 45], rollouts 5580: timing wait_actor: 0.0000, waiting: 15.2683, reset: 3.3950, save_policy_outputs: 7.0471, env_step: 10.5542, overhead:
 1.1764, prepare_next_step: 5.0380, complete_rollouts: 0.0193, enqueue_policy_requests: 0.3112, one_step: 0.0063, work: 24.5757
[2021-04-24 19:45:16,824][10025] Env runner 1, CPU aff. [40, 41, 42, 43, 12, 13, 14, 15, 16, 17, 44, 45], rollouts 5460: timing wait_actor: 0.0000, waiting: 15.4447, reset: 3.8039, save_policy_outputs: 7.0297, env_step: 10.5370, overhead:
 1.1631, prepare_next_step: 4.9704, complete_rollouts: 0.0178, enqueue_policy_requests: 0.2692, one_step: 0.0101, work: 24.4078
[2021-04-24 19:45:16,957][10023] Policy worker avg. requests 2.18, timing: init: 4.5512, wait_policy_total: 3.4930, wait_policy: 0.0051, handle_policy_step: 32.5521, one_step: 0.0000, deserialize: 5.1869, stack: 0.0710, obs_to_device: 7.2
346, forward: 7.6985, to_cpu: 9.2041, format_outputs: 0.8378, postprocess: 1.9927, weight_update: 0.0005
[2021-04-24 19:45:16,961][10022] Policy worker avg. requests 2.22, timing: init: 4.7350, wait_policy_total: 3.4288, wait_policy: 0.0051, handle_policy_step: 32.6146, one_step: 0.0000, deserialize: 5.1993, stack: 0.0714, obs_to_device: 7.2
183, forward: 7.6688, to_cpu: 9.3103, format_outputs: 0.8403, postprocess: 1.9824, weight_update: 0.0007
[2021-04-24 19:45:17,056][10013] GPU learner timing: extract: 0.3101, buffers: 0.1217, batching: 13.1366, buff_ready: 0.0639, tensors_gpu_float: 5.8634, squeeze: 0.0052, prepare: 19.2710, batcher_mem: 12.9846
[2021-04-24 19:45:17,362][10013] Train loop timing: init: 2.8980, train_wait: 0.2658, epoch_init: 0.0012, minibatch_init: 0.0006, forward_head: 0.3521, bptt_initial: 5.4228, bptt_forward_core: 0.5918, bptt: 0.6014, tail: 0.5855, vtrace: 0
.9739, losses: 0.8155, clip: 10.1797, update: 13.2627, after_optimizer: 1.4512, train: 24.2383
[2021-04-24 19:45:17,867][09985] Workers joined!
[2021-04-24 19:45:17,867][09985] Collected {0: 1040384}, FPS: 26559.7
```

The deserialize time goes up in the policy worker so this doesn't get rid of the cost of stacking, but it makes the policy worker around 10% faster and reduces deserialize+stack time by about 40%.  This leads to about a 10% FPS bump.