### PR TITLE
Fixes some of the issues with running the DMlab30 benchmark

### DIFF
--- a/sample_factory/algo/utils/misc.py
+++ b/sample_factory/algo/utils/misc.py
@@ -10,6 +10,14 @@ class ExperimentStatus:
     SUCCESS, FAILURE, INTERRUPTED = range(3)
 
 
+# custom experiments can define functions to this list to do something extra with the raw episode summaries
+# coming from the environments
+EXTRA_EPISODIC_STATS_PROCESSING = []
+
+# custom experiments or environments can append functions to this list to postprocess some summaries, or aggregate
+# summaries, or do whatever else the user wants
+EXTRA_PER_POLICY_SUMMARIES = []
+
 def memory_stats(process, device):
     memory_mb = memory_consumption_mb()
     stats = {f'memory_{process}': memory_mb}

--- a/sample_factory/envs/dmlab/dmlab_env.py
+++ b/sample_factory/envs/dmlab/dmlab_env.py
@@ -3,7 +3,7 @@ from collections import deque
 
 import numpy as np
 
-from sample_factory.algorithms.utils.algo_utils import EXTRA_EPISODIC_STATS_PROCESSING, EXTRA_PER_POLICY_SUMMARIES
+from sample_factory.algo.utils.misc import EXTRA_EPISODIC_STATS_PROCESSING, EXTRA_PER_POLICY_SUMMARIES
 from sample_factory.envs.dmlab.dmlab30 import dmlab30_level_name_to_level, \
     DMLAB30_LEVELS_THAT_USE_LEVEL_CACHE, DMLAB30_LEVELS, HUMAN_SCORES, RANDOM_SCORES, LEVEL_MAPPING
 from sample_factory.envs.dmlab.dmlab_gym import DmlabGymEnv, dmlab_level_to_level_name

--- a/sample_factory/envs/dmlab/dmlab_level_cache.py
+++ b/sample_factory/envs/dmlab/dmlab_level_cache.py
@@ -213,8 +213,8 @@ class DmlabLevelCacheGlobal:
 def dmlab_ensure_global_cache_initialized(experiment_dir, all_levels_for_experiment, num_policies, level_cache_dir):
     global DMLAB_GLOBAL_LEVEL_CACHE
 
-    assert multiprocessing.current_process().name == 'MainProcess', \
-        'make sure you initialize DMLab cache before child processes are forked'
+    # assert multiprocessing.current_process().name == 'MainProcess', \
+    #     'make sure you initialize DMLab cache before child processes are forked'
 
     DMLAB_GLOBAL_LEVEL_CACHE = []
     for policy_id in range(num_policies):

--- a/sample_factory/utils/normalize.py
+++ b/sample_factory/utils/normalize.py
@@ -41,10 +41,8 @@ class Normalizer(nn.Module):
     def _clone_tensordict(obs_dict):
         obs_clone = copy_dict_structure(obs_dict)  # creates an identical dict but with empty values
         for d, d_clone, k, x, _ in iter_dicts_recursively(obs_dict, obs_clone):
-            if x.dtype != torch.float:
-                d_clone[k] = x.float()  # this will create a copy of a tensor
-            else:
-                d_clone[k] = x.clone()  # otherwise, we explicitly clone it
+            # Previous code converted DMLab INSTR from long to float
+            d_clone[k] = x.clone()  # otherwise, we explicitly clone it
 
         return obs_clone
 


### PR DESCRIPTION
Outstanding items to resolve:

1. handlers/callbacks for EXTRA_EPISODIC_STATS_PROCESSING & EXTRA_PER_POLICY_SUMMARIES
2. obtain_env_info_in_a_separate_process() creates a cache of the env info on disk, if we use this cache the sf_context object is not updated with the custom model definition, as this is registered when a dummy env is created. I commented out this cache for the moment.
3. PBT - I switched off all the arguments related to this as it is not implemented yet.