### PR TITLE
Don't render in enjoy tests

### DIFF
--- a/sample_factory/enjoy.py
+++ b/sample_factory/enjoy.py
@@ -114,7 +114,8 @@ def enjoy(cfg):
                 obs[key] = ensure_torch_tensor(x).to(device).type(dtype)
 
             normalized_obs = actor_critic.normalize_obs(obs)
-            visualize_policy_inputs(normalized_obs)
+            if not cfg.no_render:
+                visualize_policy_inputs(normalized_obs)
             policy_outputs = actor_critic(normalized_obs, rnn_states)
 
             # sample actions from the distribution by default

--- a/tests/examples/test_example.py
+++ b/tests/examples/test_example.py
@@ -67,6 +67,7 @@ def run_test_env(
     )
     cfg.device = "cpu"
     cfg.max_num_frames = 1000
+    cfg.no_render = True
     status, avg_reward = enjoy(cfg)
 
     assert isdir(directory)


### PR DESCRIPTION
Turned off rendering for test_example.py using the no_render flag in the cfg.