### PR TITLE
Sf2 model builder

### DIFF
--- a/sample_factory/cfg/cfg.py
+++ b/sample_factory/cfg/cfg.py
@@ -454,7 +454,13 @@ def add_model_args(p: ArgumentParser):
         "--encoder_type",
         default="conv",
         type=str,
-        help="Type of the encoder. Supported: conv, mlp, resnet (feel free to define more)",
+        help="Type of the encoder. Supported: default, conv, mlp, resnet (feel free to define more)",
+    )
+    p.add_argument(
+        "--decoder_type",
+        default="identity",
+        type=str,
+        help="Type of the decord. Supported: identity, mlp (feel free to define more)",
     )
     p.add_argument(
         "--encoder_subtype", default="convnet_simple", type=str, help="Specific encoder design (see model.py)"

--- a/sample_factory/cfg/cfg.py
+++ b/sample_factory/cfg/cfg.py
@@ -463,7 +463,10 @@ def add_model_args(p: ArgumentParser):
         help="Type of the decord. Supported: identity, mlp (feel free to define more)",
     )
     p.add_argument(
-        "--encoder_subtype", default="convnet_simple", type=str, help="Specific encoder design (see model.py)"
+        "--mlp_encoder_subtype", default="mlp_mujoco", type=str, help="Specific encoder design (see model.py)"
+    )
+    p.add_argument(
+        "--conv_encoder_subtype", default="convnet_simple", type=str, help="Specific encoder design (see model.py)"
     )
     p.add_argument(
         "--encoder_custom",

--- a/sample_factory/model/model.py
+++ b/sample_factory/model/model.py
@@ -281,7 +281,7 @@ def create_actor_critic(cfg, obs_space, action_space, timing=None):
         return create_core(cfg, encoder.get_encoder_out_size())
 
     def make_decoder(core):
-        return create_decoder(cfg, core.get_encoder_out_size())
+        return create_decoder(cfg, core.get_core_out_size())
 
     if cfg.actor_critic_share_weights:
         return _ActorCriticSharedWeights(make_encoder, make_core, make_decoder, obs_space, action_space, cfg, timing)

--- a/sf_examples/dmlab_examples/dmlab_model.py
+++ b/sf_examples/dmlab_examples/dmlab_model.py
@@ -8,7 +8,7 @@ from sf_examples.dmlab_examples.dmlab30 import DMLAB_INSTRUCTIONS, DMLAB_VOCABUL
 
 class DmlabEncoder(EncoderBase):
     def __init__(self, cfg, obs_space, timing):
-        super().__init__(cfg, timing)
+        super().__init__(cfg, timing, "obs")
 
         self.basic_encoder = create_standard_encoder(cfg, obs_space, timing)
         self.encoder_out_size = self.basic_encoder.encoder_out_size

--- a/tests/model/test_encoder.py
+++ b/tests/model/test_encoder.py
@@ -1,0 +1,34 @@
+import imp
+
+import numpy as np
+import pytest
+import torch
+from gym.spaces import Box, Dict
+
+from sample_factory.cfg.arguments import parse_full_cfg, parse_sf_args
+from sample_factory.model.model_utils import create_standard_encoder
+
+
+def test_default_encoder():
+    parser, cfg = parse_sf_args(argv=["--env=dummy"])
+    cfg.encoder_type = "default"
+    obs_space = Dict(
+        {
+            "obs_1d": Box(-1, 1, shape=(1,)),
+            "obs_3d": Box(-1, 1, shape=(3, 84, 84)),
+            "obs_3d_2": Box(-1, 1, shape=(3, 64, 64)),
+        }
+    )
+    encoder = create_standard_encoder(cfg, obs_space, None)
+    obs = obs_space.sample()
+    for k in obs.keys():
+        obs[k] = torch.from_numpy(np.expand_dims(obs[k], 0))
+
+    output = encoder(obs)
+
+    print(encoder)
+    print(output.size())
+
+
+if __name__ == "__main__":
+    test_default_encoder()

--- a/tests/model/test_encoder.py
+++ b/tests/model/test_encoder.py
@@ -14,7 +14,7 @@ def test_default_encoder():
     cfg.encoder_type = "default"
     obs_space = Dict(
         {
-            "obs_1d": Box(-1, 1, shape=(1,)),
+            "obs_1d": Box(-1, 1, shape=(21,)),
             "obs_3d": Box(-1, 1, shape=(3, 84, 84)),
             "obs_3d_2": Box(-1, 1, shape=(3, 64, 64)),
         }


### PR DESCRIPTION
Initial implementation of an automatic model builder.
Adds a default mode, which will generate encoder(s) automatically based on the shape(s) of the input observation(s).
Adds a decoder option after the core of the model.

I have included limited testing, but this needs to be extended.

There are some major limitations that need to be addressed, for example image observations that are too small. e.g. 32x32 require a smaller CNN, which would need to be automatically selected.