### PR TITLE
Fixed input visualization and optimized huggingface

### DIFF
--- a/docs/get-started/huggingface.md
+++ b/docs/get-started/huggingface.md
@@ -17,6 +17,8 @@ To upload files to the HuggingFace Hub, you need to log in to your HuggingFace a
 huggingface-cli login
 ```
 
+As part of the `huggingface-cli login`, you should generate a token with write access at https://huggingface.co/settings/tokens
+
 ### Downloading Models
 
 #### Using the load_from_hub Scipt
@@ -63,18 +65,22 @@ Other relevant command line arguments are:
 
 - `--hf_repository`: The repository to push to. The model will be saved to `https://huggingface.co/hf_username/hf_repository`
 
-- `--max_num_frames`: Number of frames to evaluate on before uploading. Used to generate evaluation metrics
+- `--max_num_episodes`: Number of episodes to evaluate on before uploading. Used to generate evaluation metrics. It is recommended to use multiple episodes to generate an accurate mean and std.
+
+- `--max_num_frames`: Number of episodes to evaluate on before uploading. An alternative to `max_num_episodes`
+
+- `--no_render`: A flag that disables rendering and showing the environment steps. It is recommended to set this flag to speed up the evaluation process.
 
 You can also save a video of the model during evaluation to upload to the hub with the `--save_video` flag
 
-- `--video_frames`: The number of frames to be rendered in the video
+- `--video_frames`: The number of frames to be rendered in the video. Defaults to -1 which renders an entire episode
 
 - `--video_name`: The name of the video to save as. If `None`, will save to `replay.mp4` in your experiment directory
 
 For example:
 
 ```
-python -m sf_examples.mujoco_examples.enjoy_mujoco --algo=APPO --env=mujoco_ant --experiment=<repo_name> --train_dir=./train_dir --max_num_frames=10000 --push_to_hub --hf_username=<username> --hf_repository=<hf_repo_name> --save_video --video_frames=500
+python -m sf_examples.mujoco_examples.enjoy_mujoco --algo=APPO --env=mujoco_ant --experiment=<repo_name> --train_dir=./train_dir --max_num_episodes=10 --push_to_hub --hf_username=<username> --hf_repository=<hf_repo_name> --save_video --no_render
 ```
 
 #### Using the push_to_hub Script

--- a/sample_factory/cfg/cfg.py
+++ b/sample_factory/cfg/cfg.py
@@ -571,9 +571,15 @@ def add_eval_args(parser):
     parser.add_argument("--no_render", action="store_true", help="Do not render the environment during evaluation")
 
     parser.add_argument("--save_video", action="store_true", help="Save video instead of rendering during evaluation")
-    parser.add_argument("--video_frames", default=0, type=int, help="Number of frames to render for the video")
+    parser.add_argument(
+        "--video_frames",
+        default=-1,
+        type=int,
+        help="Number of frames to render for the video. Defaults to -1 which renders an entire episode",
+    )
     parser.add_argument("--video_name", default=None, type=str, help="Name of video to save")
     parser.add_argument("--max_num_frames", default=1e9, type=int, help="Maximum number of frames to render")
+    parser.add_argument("--max_num_episodes", default=1e9, type=int, help="Maximum number of episodes to render")
 
     parser.add_argument("--push_to_hub", action="store_true", help="Push experiment folder to HuggingFace Hub")
     parser.add_argument("--hf_username", default=None, type=str, help="HuggingFace username")

--- a/sample_factory/enjoy.py
+++ b/sample_factory/enjoy.py
@@ -47,16 +47,27 @@ def visualize_policy_inputs(normalized_obs: Dict[str, Tensor]) -> None:
     )  # this will be different frame-by-frame but probably good enough to give us an idea?
     scale = 5
     obs = cv2.resize(obs, (obs.shape[1] * scale, obs.shape[0] * scale), interpolation=cv2.INTER_NEAREST)
+
     cv2.imshow("policy inputs", obs)
+    cv2.waitKey(delay=1)
 
 
-def render_frame(cfg, env, video_frames, num_frames):
+def render_frame(cfg, env, video_frames, num_episodes, last_render_start):
     if cfg.save_video:
         frame = env.render(mode="rgb_array")
-        if num_frames < cfg.video_frames:
+        if (len(video_frames) < cfg.video_frames) or (cfg.video_frames < 0 and num_episodes == 0):
             video_frames.append(frame)
     else:
-        env.render()
+        if not cfg.no_render:
+            target_delay = 1.0 / cfg.fps if cfg.fps > 0 else 0
+            current_delay = time.time() - last_render_start
+            time_wait = target_delay - current_delay
+
+            if time_wait > 0:
+                # log.info('Wait time %.3f', time_wait)
+                time.sleep(time_wait)
+
+            env.render()
 
 
 def enjoy(cfg):
@@ -106,9 +117,10 @@ def enjoy(cfg):
     obs = env.reset()
     rnn_states = torch.zeros([env.num_agents, get_hidden_size(cfg)], dtype=torch.float32, device=device)
     episode_reward = None
-    finished_episode = [False] * env.num_agents
+    finished_episode = [False for _ in range(env.num_agents)]
 
     video_frames = []
+    num_episodes = 0
 
     with torch.inference_mode():
         while not max_frames_reached(num_frames):
@@ -134,18 +146,9 @@ def enjoy(cfg):
             rnn_states = policy_outputs["new_rnn_states"]
 
             for _ in range(render_action_repeat):
-                if not cfg.no_render:
-                    target_delay = 1.0 / cfg.fps if cfg.fps > 0 else 0
-                    current_delay = time.time() - last_render_start
-                    time_wait = target_delay - current_delay
 
-                    if time_wait > 0:
-                        # log.info('Wait time %.3f', time_wait)
-                        time.sleep(time_wait)
-
-                    last_render_start = time.time()
-
-                    render_frame(cfg, env, video_frames, num_frames)
+                render_frame(cfg, env, video_frames, num_episodes, last_render_start)
+                last_render_start = time.time()
 
                 obs, rew, dones, infos = env.step(actions)
                 infos = [{} for _ in range(env_info.num_agents)] if infos is None else infos
@@ -179,11 +182,11 @@ def enjoy(cfg):
                         )
                         rnn_states[agent_i] = torch.zeros([get_hidden_size(cfg)], dtype=torch.float32, device=device)
                         episode_reward[agent_i] = 0
+                        num_episodes += 1
 
                 # if episode terminated synchronously for all agents, pause a bit before starting a new one
                 if all(dones):
-                    if not cfg.no_render:
-                        render_frame(cfg, env, video_frames, num_frames)
+                    render_frame(cfg, env, video_frames, num_episodes, last_render_start)
                     time.sleep(0.05)
 
                 if all(finished_episode):
@@ -216,6 +219,9 @@ def enjoy(cfg):
                 #     key = f'PLAYER{player}_FRAGCOUNT'
                 #     if key in infos[0]:
                 #         log.debug('Score for player %d: %r', player, infos[0][key])
+
+            if num_episodes >= cfg.max_num_episodes:
+                break
 
     env.close()
 

--- a/sample_factory/huggingface/huggingface_utils.py
+++ b/sample_factory/huggingface/huggingface_utils.py
@@ -4,16 +4,26 @@ import cv2
 import numpy as np
 from huggingface_hub import HfApi, Repository, repocard, upload_file, upload_folder
 
-from sample_factory.utils.utils import experiment_dir, log, project_tmp_dir
+from sample_factory.utils.utils import log, project_tmp_dir
+
+MIN_FRAME_SIZE = 180
 
 
 def generate_replay_video(dir_path: str, frames: list, fps: int):
     tmp_name = os.path.join(project_tmp_dir(), "replay.mp4")
     video_name = os.path.join(dir_path, "replay.mp4")
     frame_size = (frames[0].shape[0], frames[0].shape[1])
+    resize = False
+
+    if min(frame_size) < MIN_FRAME_SIZE:
+        resize = True
+        scaling_factor = MIN_FRAME_SIZE / min(frame_size)
+        frame_size = (int(frame_size[0] * scaling_factor), int(frame_size[1] * scaling_factor))
 
     video = cv2.VideoWriter(tmp_name, cv2.VideoWriter_fourcc(*"mp4v"), fps, frame_size)
     for frame in frames:
+        if resize:
+            frame = cv2.resize(frame, frame_size, interpolation=cv2.INTER_AREA)
         video.write(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
     video.release()
     os.system(f"ffmpeg -y -i {tmp_name} -vcodec libx264 {video_name}")


### PR DESCRIPTION
Fixed `visualize_policy_inputs` not displaying by adding `cv2.waitKey(delay=1)` to show image without delay

Improved video generation for huggingface by adding parameters to train for a set number of episodes, and disabled time.sleep during video generation to speed up evaluation when `no_render` 