### PR TITLE
torch has cuda bugs on 1.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     # might want to add max versions restrictions, i.e. torch < 2?
     install_requires=[
         'numpy>=1.18.1',
-        'torch>=1.6',
+        'torch>=1.6,<1.12',
         'gym>=0.17.1',
         'tensorboard>=1.15.0',
         'tensorboardx>=2.0',


### PR DESCRIPTION
Got this error when running megaverse on sf1

RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method