### PR TITLE
Fixed training enqueue and heartbeat changes

### DIFF
--- a/sample_factory/algo/learning/batcher.py
+++ b/sample_factory/algo/learning/batcher.py
@@ -235,6 +235,9 @@ class Batcher(HeartbeatStoppableEventLoopObject):
                 self.resume_experience_collection.emit()
 
             self.available_batches.append(batch_idx)
+
+            self._maybe_enqueue_new_training_batches()
+
             # log.debug(
             #     f"{self.object_id} finished processing batch {batch_idx}, available batches: {self.available_batches}, {training_iteration=}"
             # )

--- a/sample_factory/algo/runners/runner.py
+++ b/sample_factory/algo/runners/runner.py
@@ -504,7 +504,7 @@ class Runner(EventLoopObject, Configurable):
         if component_type not in self.heartbeat_dict:
             self.heartbeat_dict[component_type] = {}
         type_dict = self.heartbeat_dict[component_type]
-        type_dict[component.object_id] = time.time()
+        type_dict[component.object_id] = None
         component.heartbeat.connect(self._receive_heartbeat)
 
     def _receive_heartbeat(self, component_type: type, component_id: str):
@@ -513,7 +513,9 @@ class Runner(EventLoopObject, Configurable):
         """
         curr_time = time.time()
         heartbeat_time = self.heartbeat_dict[component_type][component_id]
-        if curr_time - heartbeat_time > self.heartbeat_report_sec:
+        if heartbeat_time is None:
+            log.info(f"Heartbeat connected on {component_id}")
+        elif curr_time - heartbeat_time > self.heartbeat_report_sec:
             log.info(f"Heartbeat reconnected after {int(curr_time - heartbeat_time)} seconds from {component_id}")
         self.heartbeat_dict[component_type][component_id] = curr_time
 
@@ -525,20 +527,26 @@ class Runner(EventLoopObject, Configurable):
         curr_time = time.time()
         comp_list = []
         type_list = []
+        none_list = []
         for component_type, heartbeat_dict in self.heartbeat_dict.items():
             num_components = len(heartbeat_dict)
             num_stopped = 0
             for component_id, heartbeat_time in heartbeat_dict.items():
+                if heartbeat_time is None:
+                    none_list.append(component_id)
+                    continue
                 if curr_time - heartbeat_time > self.heartbeat_report_sec:
                     comp_list.append(f"{component_id} ({(int(curr_time - heartbeat_time))} seconds)")
                     num_stopped += 1
             if num_stopped == num_components:
                 type_list.append(str(component_type))
 
+        if len(none_list) > 0:
+            log.debug(f"Components not started: {', '.join(none_list)}")
         if len(comp_list) > 0:
-            log.error("No heartbeat for components: " + ", ".join(comp_list))
+            log.error(f"No heartbeat for components: {', '.join(comp_list)}")
         if len(type_list) > 0:
-            log.error("Stopping training from lack of heartbeats from " + ", ".join(type_list))
+            log.error(f"Stopping training from lack of heartbeats from {', '.join(type_list)}")
             self._stop_training()
 
     def _setup_component_termination(self, stop_signal: signal, component_to_stop: HeartbeatStoppableEventLoopObject):


### PR DESCRIPTION
Added _maybe_enqueue_new_training_batches to fix error with learner not pulling trajectories from the queue.

Also changed heartbeat to start when component sends first signal, since rollout workers sometimes don't start right away in async mode.