### PR TITLE
Implements MultiInputEncoder

### DIFF
--- a/sample_factory/algo/learning/learner.py
+++ b/sample_factory/algo/learning/learner.py
@@ -206,6 +206,8 @@ class Learner(Configurable):
 
         # trainable torch module
         self.actor_critic = create_actor_critic(self.cfg, self.env_info.obs_space, self.env_info.action_space)
+        log.debug("Created Actor Critic model with architecture:")
+        log.debug(self.actor_critic)
         self.actor_critic.model_to_device(self.device)
 
         def share_mem(t):

--- a/sample_factory/model/encoder.py
+++ b/sample_factory/model/encoder.py
@@ -77,7 +77,7 @@ class MlpEncoder(Encoder):
         obs_shape = get_obs_shape(obs_space)
 
         mlp_layers: List[int] = cfg.encoder_mlp_layers
-        self.mlp_head = create_mlp(mlp_layers, obs_shape, nonlinearity(cfg))
+        self.mlp_head = create_mlp(mlp_layers, obs_shape[0], nonlinearity(cfg))
         if len(mlp_layers) > 0:
             self.mlp_head = torch.jit.script(self.mlp_head)
         self.encoder_out_size = calc_num_elements(self.mlp_head, obs_shape)

--- a/sample_factory/model/encoder.py
+++ b/sample_factory/model/encoder.py
@@ -241,28 +241,7 @@ def default_make_encoder_func(cfg: Config, obs_space: ObsSpace) -> Encoder:
     Analyze the observation space and create either a convolutional or an MLP encoder depending on
     whether this is an image-based environment or environment with vector observations.
     """
-    return MultiInputEncoder(cfg, obs_space)
     # we only support dict observation spaces - envs with non-dict obs spaces use a wrapper
     # main subspace used to determine the encoder type is called "obs". For envs with multiple subspaces,
     # this function needs to be overridden (see vizdoom or dmlab encoders for example)
-    assert isinstance(obs_space, spaces.Dict), f"Only dict observation spaces are supported, got {obs_space}"
-    main_obs_space = obs_space.spaces["obs"]
-
-    if isinstance(main_obs_space, spaces.Box):
-        # determine whether this is an image-based environment
-        ndim: int = len(main_obs_space.shape)
-        if ndim == 1:
-            return MlpEncoder(cfg, obs_space)
-        elif 2 <= ndim <= 3:
-            return make_img_encoder(cfg, obs_space)
-        else:
-            raise NotImplementedError(f"Unsupported observation space {main_obs_space}, {ndim=}")
-    else:
-        raise NotImplementedError(
-            f"Observation space {main_obs_space} not supported. Override make encoder func or add support for it"
-            f"in {__file__}"
-        )
-
-
-def make_multi_encoder(cfg: Config, obs_space, ObsSpace) -> Encoder:
     return MultiInputEncoder(cfg, obs_space)

--- a/sample_factory/model/model_utils.py
+++ b/sample_factory/model/model_utils.py
@@ -39,10 +39,11 @@ def nonlinearity(cfg: Config) -> nn.Module:
 def get_obs_shape(obs_space: ObsSpace) -> AttrDict:
     obs_shape = AttrDict()
     if hasattr(obs_space, "spaces"):
+        assert 0, "this should be called with single space"
         for key, space in obs_space.spaces.items():
             obs_shape[key] = space.shape
     else:
-        obs_shape.obs = obs_space.shape
+        obs_shape = obs_space.shape
 
     return obs_shape
 

--- a/sample_factory/model/model_utils.py
+++ b/sample_factory/model/model_utils.py
@@ -36,18 +36,6 @@ def nonlinearity(cfg: Config) -> nn.Module:
         raise Exception("Unknown nonlinearity")
 
 
-def get_obs_shape(obs_space: ObsSpace) -> AttrDict:
-    obs_shape = AttrDict()
-    if hasattr(obs_space, "spaces"):
-        assert 0, "this should be called with single space"
-        for key, space in obs_space.spaces.items():
-            obs_shape[key] = space.shape
-    else:
-        obs_shape = obs_space.shape
-
-    return obs_shape
-
-
 def fc_layer(in_features: int, out_features: int, bias=True, spec_norm=False) -> nn.Module:
     layer = nn.Linear(in_features, out_features, bias)
     if spec_norm:

--- a/sf_examples/train_custom_env_custom_model.py
+++ b/sf_examples/train_custom_env_custom_model.py
@@ -97,7 +97,7 @@ class CustomEncoder(Encoder):
         ]
 
         self.conv_head = nn.Sequential(*conv_layers)
-        self.conv_head_out_size = calc_num_elements(self.conv_head, obs_shape.obs)
+        self.conv_head_out_size = calc_num_elements(self.conv_head, obs_shape)
 
     def forward(self, obs_dict):
         # we always work with dictionary observations. Primary observation is available with the key 'obs'

--- a/sf_examples/train_custom_env_custom_model.py
+++ b/sf_examples/train_custom_env_custom_model.py
@@ -18,7 +18,7 @@ from sample_factory.algo.utils.torch_utils import calc_num_elements
 from sample_factory.cfg.arguments import parse_full_cfg, parse_sf_args
 from sample_factory.envs.env_utils import register_env
 from sample_factory.model.encoder import Encoder
-from sample_factory.model.model_utils import get_obs_shape, nonlinearity
+from sample_factory.model.model_utils import nonlinearity
 from sample_factory.train import run_rl
 from sample_factory.utils.typing import Config, ObsSpace
 
@@ -87,7 +87,7 @@ class CustomEncoder(Encoder):
     def __init__(self, cfg, obs_space):
         super().__init__(cfg)
 
-        obs_shape = get_obs_shape(obs_space)
+        obs_shape = obs_space["obs"].shape
 
         conv_layers = [
             nn.Conv2d(1, 8, 3, stride=2),

--- a/sf_examples/vizdoom_examples/doom/doom_model.py
+++ b/sf_examples/vizdoom_examples/doom/doom_model.py
@@ -26,7 +26,7 @@ class VizdoomEncoder(Encoder):
                 nn.Linear(128, 128),
                 nonlinearity(cfg),
             )
-            measurements_out_size = calc_num_elements(self.measurements_head, obs_shape.measurements)
+            measurements_out_size = calc_num_elements(self.measurements_head, obs_shape)
             self.encoder_out_size += measurements_out_size
 
         log.debug("Policy head output size: %r", self.get_out_size())

--- a/sf_examples/vizdoom_examples/doom/doom_model.py
+++ b/sf_examples/vizdoom_examples/doom/doom_model.py
@@ -13,26 +13,24 @@ class VizdoomEncoder(Encoder):
         super().__init__(cfg)
 
         # reuse the default image encoder
-        self.basic_encoder = make_img_encoder(cfg, obs_space)
-
+        self.basic_encoder = make_img_encoder(cfg, obs_space["obs"])
         self.encoder_out_size = self.basic_encoder.get_out_size()
-        obs_shape = get_obs_shape(obs_space)
 
         self.measurements_head = None
-        if "measurements" in obs_shape:
+        if "measurements" in obs_space.keys():
             self.measurements_head = nn.Sequential(
-                nn.Linear(obs_shape.measurements[0], 128),
+                nn.Linear(obs_space["measurements"].shape[0], 128),
                 nonlinearity(cfg),
                 nn.Linear(128, 128),
                 nonlinearity(cfg),
             )
-            measurements_out_size = calc_num_elements(self.measurements_head, obs_shape)
+            measurements_out_size = calc_num_elements(self.measurements_head, obs_space["measurements"].shape)
             self.encoder_out_size += measurements_out_size
 
         log.debug("Policy head output size: %r", self.get_out_size())
 
     def forward(self, obs_dict):
-        x = self.basic_encoder(obs_dict)
+        x = self.basic_encoder(obs_dict["obs"])
 
         if self.measurements_head is not None:
             measurements = self.measurements_head(obs_dict["measurements"].float())

--- a/sf_examples/vizdoom_examples/doom/doom_model.py
+++ b/sf_examples/vizdoom_examples/doom/doom_model.py
@@ -3,7 +3,7 @@ from torch import nn
 
 from sample_factory.algo.utils.torch_utils import calc_num_elements
 from sample_factory.model.encoder import Encoder, make_img_encoder
-from sample_factory.model.model_utils import get_obs_shape, nonlinearity
+from sample_factory.model.model_utils import nonlinearity
 from sample_factory.utils.typing import Config, ObsSpace
 from sample_factory.utils.utils import log
 

--- a/tests/algo/test_model_builder.py
+++ b/tests/algo/test_model_builder.py
@@ -58,8 +58,3 @@ class TestModelBuilder:
 
         assert set(encoder.obs_keys) == set(obs_space.keys())
         assert output.shape == (1, 512 * len(obs_space))
-
-
-if __name__ == "__main__":
-    t = TestModelBuilder()
-    t.test_default_encoder()

--- a/tests/algo/test_model_builder.py
+++ b/tests/algo/test_model_builder.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pytest
+import torch
+from gym.spaces import Box, Dict
+
+from sample_factory.cfg.arguments import parse_sf_args
+from sample_factory.model.encoder import default_make_encoder_func
+
+
+class TestModelBuilder:
+    @pytest.mark.parametrize(
+        "obs_space",
+        [
+            Dict(
+                {
+                    "obs_1d": Box(-1, 1, shape=(21,)),
+                }
+            ),
+            Dict(
+                {
+                    "obs_1d": Box(-1, 1, shape=(21,)),
+                    "obs_3d": Box(-1, 1, shape=(3, 84, 84)),
+                }
+            ),
+            Dict(
+                {
+                    "obs_1d": Box(-1, 1, shape=(21,)),
+                    "obs_3d": Box(-1, 1, shape=(3, 84, 84)),
+                    "obs_3d_2": Box(-1, 1, shape=(3, 64, 64)),
+                }
+            ),
+            Dict(
+                {
+                    "obs": Box(-1, 1, shape=(21,)),
+                }
+            ),
+            Dict(
+                {
+                    "obs": Box(-1, 1, shape=(3, 84, 84)),
+                }
+            ),
+            Dict(
+                {
+                    "obs": Box(-1, 1, shape=(3, 84, 84)),
+                    "measurements": Box(-1, 1, shape=(21,)),
+                }
+            ),
+        ],
+    )
+    def test_default_make_encoder_func(self, obs_space):
+        parser, cfg = parse_sf_args(argv=["--env=dummy"])
+        encoder = default_make_encoder_func(cfg, obs_space)
+        obs = obs_space.sample()
+        for k in obs.keys():
+            obs[k] = torch.from_numpy(np.expand_dims(obs[k], 0))
+
+        output = encoder(obs)
+
+        assert set(encoder.obs_keys) == set(obs_space.keys())
+        assert output.shape == (1, 512 * len(obs_space))
+
+
+if __name__ == "__main__":
+    t = TestModelBuilder()
+    t.test_default_encoder()

--- a/tests/algo/test_rnn.py
+++ b/tests/algo/test_rnn.py
@@ -44,7 +44,7 @@ class TestPackedSequences:
             loopy_out = torch.stack(loopy_out, dim=1).view(N * T, -1)
 
             norm = torch.norm(packed_out - loopy_out)
-            print(norm)
+
             assert norm < norm_tolerance
             assert np.allclose(packed_out.detach().numpy(), loopy_out.detach().numpy(), atol=2e-6)
 

--- a/tests/model/test_encoder.py
+++ b/tests/model/test_encoder.py
@@ -1,0 +1,34 @@
+import imp
+
+import numpy as np
+import pytest
+import torch
+from gym.spaces import Box, Dict
+
+from sample_factory.cfg.arguments import parse_full_cfg, parse_sf_args
+from sample_factory.model.encoder import Encoder, default_make_encoder_func
+
+
+def test_default_encoder():
+    parser, cfg = parse_sf_args(argv=["--env=dummy"])
+    cfg.encoder_type = "default"
+    obs_space = Dict(
+        {
+            "obs_1d": Box(-1, 1, shape=(21,)),
+            "obs_3d": Box(-1, 1, shape=(3, 84, 84)),
+            "obs_3d_2": Box(-1, 1, shape=(3, 64, 64)),
+        }
+    )
+    encoder = default_make_encoder_func(cfg, obs_space)
+    obs = obs_space.sample()
+    for k in obs.keys():
+        obs[k] = torch.from_numpy(np.expand_dims(obs[k], 0))
+
+    output = encoder(obs)
+
+    print(encoder)
+    print(output.size())
+
+
+if __name__ == "__main__":
+    test_default_encoder()


### PR DESCRIPTION
Creates a MultiInputEncoder class that builds Encoders for any Dict observation space.
Updates dmlab and vizdoom custom models to be compatible with this change.
Includes an encoder builder test in tests/algo/test_model_builder.py

