### PR TITLE
Sf2 doom pbt

### DIFF
--- a/.core-coveragerc
+++ b/.core-coveragerc
@@ -3,6 +3,6 @@ omit =
     setup.py
     tests/*
     sample_factory/runner/runs/*
-    sf_examples/dmlab_examples/*
+    sf_examples/dmlab/*
     sf_examples/isaacgym_examples/*
-    sf_examples/vizdoom_examples/*
+    sf_examples/vizdoom/*

--- a/.gitignore
+++ b/.gitignore
@@ -143,4 +143,4 @@ wandb/
 *~
 
 cmake-build*
-sf_examples/vizdoom_examples/doom/multiplayer/tests/_vizdoom/
+sf_examples/vizdoom/doom/multiplayer/tests/_vizdoom/

--- a/docs/environment-integrations/atari.md
+++ b/docs/environment-integrations/atari.md
@@ -10,7 +10,7 @@ pip install sample-factory[atari]
 
 ### Running Experiments
 
-Run Atari experiments with the scripts in `sf_examples.atari_examples`.
+Run Atari experiments with the scripts in `sf_examples.atari`.
 
 The default parameters have been chosen to match CleanRL's configuration (see reports below) and are not tuned for throughput.
 TODO: provide parameters that result in faster training.
@@ -19,24 +19,24 @@ TODO: provide parameters that result in faster training.
 To train a model in the `BreakoutNoFrameskip-v4` enviornment:
 
 ```
-python -m sf_examples.atari_examples.train_atari --algo=APPO --env=atari_breakout --experiment="Experiment Name"
+python -m sf_examples.atari.train_atari --algo=APPO --env=atari_breakout --experiment="Experiment Name"
 ```
 
 To visualize the training results, use the `enjoy_atari` script:
 
 ```
-python -m sf_examples.atari_examples.enjoy_atari --algo=APPO --env=atari_breakout --experiment="Experiment Name"
+python -m sf_examples.atari.enjoy_atari --algo=APPO --env=atari_breakout --experiment="Experiment Name"
 ```
 
 Multiple experiments can be run in parallel with the runner module. `atari_envs` is an example runner script that runs atari envs with 4 seeds. 
 
 ```
-python -m sample_factory.runner.run --run=sf_examples.atari_examples.experiments.atari_envs --runner=processes --max_parallel=8  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1
+python -m sample_factory.runner.run --run=sf_examples.atari.experiments.atari_envs --runner=processes --max_parallel=8  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1
 ```
 
 #### List of Supported Environments
 
-Specify the environment to run with the `--env` command line parameter. The following Atari v4 environments are supported out of the box, and more enviornments can be added as needed in `sf_examples.atari_examples.atari.atari_utils`
+Specify the environment to run with the `--env` command line parameter. The following Atari v4 environments are supported out of the box, and more enviornments can be added as needed in `sf_examples.atari.atari.atari_utils`
 
 | Atari Environment Name   | Atari Command Line Parameter |
 | -----------------------   | ------------------------------------- |

--- a/docs/environment-integrations/vizdoom.md
+++ b/docs/environment-integrations/vizdoom.md
@@ -8,49 +8,49 @@ after which the latest VizDoom can be installed from PyPI:
 
 ### Running Experiments
 
-Run MuJoCo experiments with the scripts in `sf_examples.vizdoom_examples`. 
+Run MuJoCo experiments with the scripts in `sf_examples.vizdoom`. 
 
 Train for 4B env steps (also can be stopped at any time with Ctrl+C and resumed by using the same cmd).
 This is more or less optimal training setup for a 10-core machine.
 
 ```
-python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_battle --train_for_env_steps=4000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --batch_size=2048 --wide_aspect_ratio=False --num_workers=20 --num_envs_per_worker=20 --num_policies=1  --experiment=doom_battle_w20_v20
+python -m sf_examples.vizdoom.train_vizdoom --env=doom_battle --train_for_env_steps=4000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --batch_size=2048 --wide_aspect_ratio=False --num_workers=20 --num_envs_per_worker=20 --num_policies=1  --experiment=doom_battle_w20_v20
 ```
 
 Run at any point to visualize the experiment:
 
 ```
-python -m sf_examples.vizdoom_examples.enjoy_vizdoom --env=doom_battle --algo=APPO --experiment=doom_battle_w20_v20
+python -m sf_examples.vizdoom.enjoy_vizdoom --env=doom_battle --algo=APPO --experiment=doom_battle_w20_v20
 ```
 
-Runner scripts are also provided in `sf_examples.vizdoom_examples.experiments` to run experiments in parallel or on slurm.
+Runner scripts are also provided in `sf_examples.vizdoom.experiments` to run experiments in parallel or on slurm.
 
 #### Reproducing Paper Results
 
 Train on one of the 6 "basic" VizDoom environments:
 
 ```
-python -m sf_examples.vizdoom_examples.train_vizdoom --train_for_env_steps=500000000 --algo=APPO --env=doom_my_way_home --env_frameskip=4 --use_rnn=True --num_workers=36 --num_envs_per_worker=8 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --experiment=doom_basic_envs
+python -m sf_examples.vizdoom.train_vizdoom --train_for_env_steps=500000000 --algo=APPO --env=doom_my_way_home --env_frameskip=4 --use_rnn=True --num_workers=36 --num_envs_per_worker=8 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --experiment=doom_basic_envs
 ```
 
 Doom "battle" and "battle2" environments, 36-core server (72 logical cores) with 4 GPUs:
 ```
-python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_battle --train_for_env_steps=4000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=72 --num_envs_per_worker=8 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --max_grad_norm=0.0 --experiment=doom_battle
-python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_battle2 --train_for_env_steps=4000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=72 --num_envs_per_worker=8 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --max_grad_norm=0.0 --experiment=doom_battle_2
+python -m sf_examples.vizdoom.train_vizdoom --env=doom_battle --train_for_env_steps=4000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=72 --num_envs_per_worker=8 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --max_grad_norm=0.0 --experiment=doom_battle
+python -m sf_examples.vizdoom.train_vizdoom --env=doom_battle2 --train_for_env_steps=4000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=72 --num_envs_per_worker=8 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --max_grad_norm=0.0 --experiment=doom_battle_2
 ```
 
 Duel and deathmatch versus bots, population-based training, 36-core server:
 
 ```
-python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_duel_bots --train_for_seconds=360000 --algo=APPO --gamma=0.995 --env_frameskip=2 --use_rnn=True --reward_scale=0.5 --num_workers=72 --num_envs_per_worker=32 --num_policies=8 --batch_size=2048 --benchmark=False --res_w=128 --res_h=72 --wide_aspect_ratio=False --pbt_replace_reward_gap=0.2 --pbt_replace_reward_gap_absolute=3.0 --pbt_period_env_steps=5000000 --save_milestones_sec=1800 --with_pbt=True --experiment=doom_duel_bots
-python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_deathmatch_bots --train_for_seconds=3600000 --algo=APPO --use_rnn=True --gamma=0.995 --env_frameskip=2 --num_workers=80 --num_envs_per_worker=24 --num_policies=8 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=False --with_pbt=True --pbt_period_env_steps=5000000 --experiment=doom_deathmatch_bots
+python -m sf_examples.vizdoom.train_vizdoom --env=doom_duel_bots --train_for_seconds=360000 --algo=APPO --gamma=0.995 --env_frameskip=2 --use_rnn=True --reward_scale=0.5 --num_workers=72 --num_envs_per_worker=32 --num_policies=8 --batch_size=2048 --benchmark=False --res_w=128 --res_h=72 --wide_aspect_ratio=False --pbt_replace_reward_gap=0.2 --pbt_replace_reward_gap_absolute=3.0 --pbt_period_env_steps=5000000 --save_milestones_sec=1800 --with_pbt=True --experiment=doom_duel_bots
+python -m sf_examples.vizdoom.train_vizdoom --env=doom_deathmatch_bots --train_for_seconds=3600000 --algo=APPO --use_rnn=True --gamma=0.995 --env_frameskip=2 --num_workers=80 --num_envs_per_worker=24 --num_policies=8 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=False --with_pbt=True --pbt_period_env_steps=5000000 --experiment=doom_deathmatch_bots
 ```
 
 Duel and deathmatch self-play, PBT, 36-core server:
 
 ```
-python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_duel --train_for_seconds=360000 --algo=APPO --gamma=0.995 --env_frameskip=2 --use_rnn=True --num_workers=72 --num_envs_per_worker=16 --num_policies=8 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=False --benchmark=False --pbt_replace_reward_gap=0.5 --pbt_replace_reward_gap_absolute=0.35 --pbt_period_env_steps=5000000 --with_pbt=True --pbt_start_mutation=100000000 --experiment=doom_duel_full
-python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_deathmatch_full --train_for_seconds=360000 --algo=APPO --gamma=0.995 --env_frameskip=2 --use_rnn=True --num_workers=72 --num_envs_per_worker=16 --num_policies=8 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=False --benchmark=False --pbt_replace_reward_gap=0.1 --pbt_replace_reward_gap_absolute=0.1 --pbt_period_env_steps=5000000 --with_pbt=True --pbt_start_mutation=100000000 --experiment=doom_deathmatch_full
+python -m sf_examples.vizdoom.train_vizdoom --env=doom_duel --train_for_seconds=360000 --algo=APPO --gamma=0.995 --env_frameskip=2 --use_rnn=True --num_workers=72 --num_envs_per_worker=16 --num_policies=8 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=False --benchmark=False --pbt_replace_reward_gap=0.5 --pbt_replace_reward_gap_absolute=0.35 --pbt_period_env_steps=5000000 --with_pbt=True --pbt_start_mutation=100000000 --experiment=doom_duel_full
+python -m sf_examples.vizdoom.train_vizdoom --env=doom_deathmatch_full --train_for_seconds=360000 --algo=APPO --gamma=0.995 --env_frameskip=2 --use_rnn=True --num_workers=72 --num_envs_per_worker=16 --num_policies=8 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=False --benchmark=False --pbt_replace_reward_gap=0.1 --pbt_replace_reward_gap_absolute=0.1 --pbt_period_env_steps=5000000 --with_pbt=True --pbt_start_mutation=100000000 --experiment=doom_deathmatch_full
 ```
 
 Reproducing benchmarking results:
@@ -58,20 +58,20 @@ Reproducing benchmarking results:
 This achieves 50K+ framerate on a 10-core machine (Intel Core i9-7900X):
 
 ```
-python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_benchmark --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=20 --num_envs_per_worker=32 --num_policies=1 --batch_size=4096 --experiment=doom_battle_appo_fps_20_32 --res_w=128 --res_h=72 --wide_aspect_ratio=False --policy_workers_per_policy=2 --worker_num_splits=2
+python -m sf_examples.vizdoom.train_vizdoom --env=doom_benchmark --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=20 --num_envs_per_worker=32 --num_policies=1 --batch_size=4096 --experiment=doom_battle_appo_fps_20_32 --res_w=128 --res_h=72 --wide_aspect_ratio=False --policy_workers_per_policy=2 --worker_num_splits=2
 ```
 
 This achieves 100K+ framerate on a 36-core machine:
 
 ```
-python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_benchmark --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=72 --num_envs_per_worker=24 --num_policies=1 --batch_size=8192 --wide_aspect_ratio=False --experiment=doom_battle_appo_w72_v24 --policy_workers_per_policy=2
+python -m sf_examples.vizdoom.train_vizdoom --env=doom_benchmark --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=72 --num_envs_per_worker=24 --num_policies=1 --batch_size=8192 --wide_aspect_ratio=False --experiment=doom_battle_appo_w72_v24 --policy_workers_per_policy=2
 ```
 
 ### Results
 
 #### Reports
 
-1. We reproduced the paper results in SF2 in the Battle and Battle2 and compared the results using input normalization. Input normalization has improved results in the Battle environment. This experiment with input normalization was run with `sf_examples.vizdoom_examples.experiments.sf2_doom_battle_envs`. Note that `normalize_input=True` is set compared to the results from the paper
+1. We reproduced the paper results in SF2 in the Battle and Battle2 and compared the results using input normalization. Input normalization has improved results in the Battle environment. This experiment with input normalization was run with `sf_examples.vizdoom.experiments.sf2_doom_battle_envs`. Note that `normalize_input=True` is set compared to the results from the paper
     - https://wandb.ai/andrewzhang505/sample_factory/reports/VizDoom-Battle-Environments--VmlldzoyMzcyODQx
 
 2. In SF2's bot environments (deathmatch_bots and duel_bots), we trained the agents against randomly generated bots as opposed to a curriculum of increasing bot difficulty. This is because the ViZDoom environment no longer provides the bots used in the curriculum, and SF2 no longer requires the curriculum to train properly. However, due to the differences in bot difficulty, the current training results are no longer comparable to the paper. An example training curve on deathmatch_bots with the same parameters as in the paper is shown below:

--- a/docs/get-started/basic-usage.md
+++ b/docs/get-started/basic-usage.md
@@ -68,6 +68,6 @@ etc. Consult experiment-specific `cfg.json` and the source code for full list of
 
 `sample_factory.envs.dmlab.dmlab_model` and `sample_factory.envs.doom.doom_model` demonstrate how to handle environment-specific
 additional input spaces (e.g. natural language and/or numerical vector inputs).
-Script `sample_factory_examples/train_custom_env_custom_model.py` demonstrates how users can define a fully custom
+Script `sf_examples/train_custom_env_custom_model.py` demonstrates how users can define a fully custom
 environment-specific encoder. Whenever a fully custom actor-critic architecture is required, users are welcome
 to override `_ActorCriticBase` following examples in `sample_factory/algorithms/appo/model.py`.

--- a/docs/get-started/huggingface.md
+++ b/docs/get-started/huggingface.md
@@ -48,7 +48,7 @@ git clone <URL of HuggingFace Repo>
 After downloading the model, you can run the models in the repo with the enjoy script corresponding to your environment. For example, if you are downloading a `mujoco-ant` model, it can be run with:
 
 ```
-python -m sf_examples.mujoco_examples.enjoy_mujoco --algo=APPO --env=mujoco_ant --experiment=<repo_name> --train_dir=./train_dir
+python -m sf_examples.mujoco.enjoy_mujoco --algo=APPO --env=mujoco_ant --experiment=<repo_name> --train_dir=./train_dir
 ```
 
 Note, you may have to specify the `--train_dir` if your local train_dir has a different path than the one in the `cfg.json`
@@ -82,7 +82,7 @@ You can also save a video of the model during evaluation to upload to the hub wi
 For example:
 
 ```
-python -m sf_examples.mujoco_examples.enjoy_mujoco --algo=APPO --env=mujoco_ant --experiment=<repo_name> --train_dir=./train_dir --max_num_episodes=10 --push_to_hub --hf_username=<username> --hf_repository=<hf_repo_name> --save_video --no_render
+python -m sf_examples.mujoco.enjoy_mujoco --algo=APPO --env=mujoco_ant --experiment=<repo_name> --train_dir=./train_dir --max_num_episodes=10 --push_to_hub --hf_username=<username> --hf_repository=<hf_repo_name> --save_video --no_render
 ```
 
 #### Using the push_to_hub Script

--- a/docs/get-started/running-slurm.md
+++ b/docs/get-started/running-slurm.md
@@ -51,7 +51,7 @@ Activate your conda environment with `bash` and `conda activate sf2` then `cd sa
 
 Run your runner script - an example mujuco runner (replace run, slurm_sbatch_template, and slurm_workdir with appropriate values)
 ```
-python -m sample_factory.runner.run --runner=slurm --slurm_workdir=./slurm_mujoco --experiment_suffix=slurm --slurm_gpus_per_job=1 --slurm_cpus_per_gpu=16 --slurm_sbatch_template=./sample_factory/runner/slurm/sbatch_template.sh --pause_between=1 --slurm_print_only=False --run=sf_examples.mujoco_examples.experiments.mujoco_all_envs
+python -m sample_factory.runner.run --runner=slurm --slurm_workdir=./slurm_mujoco --experiment_suffix=slurm --slurm_gpus_per_job=1 --slurm_cpus_per_gpu=16 --slurm_sbatch_template=./sample_factory/runner/slurm/sbatch_template.sh --pause_between=1 --slurm_print_only=False --run=sf_examples.mujoco.experiments.mujoco_all_envs
 ```
 
 The `slurm_gpus_per_job` and `slurm_cpus_per_gpu` determine the resources allocated to each job. You can view the jobs without running them by setting `slurm_print_only=True`.

--- a/sample_factory/algo/sampling/non_batched_sampling.py
+++ b/sample_factory/algo/sampling/non_batched_sampling.py
@@ -295,7 +295,8 @@ class ActorState:
             episode_extra_stats=info.get("episode_extra_stats", dict()),
         )
 
-        stats["true_objective"] = info.get("true_objective", self.last_episode_reward)
+        if (true_objective := info.get("true_objective", self.last_episode_reward)) is not None:
+            stats["true_objective"] = true_objective
 
         episode_wrapper_stats = record_episode_statistics_wrapper_stats(info)
         if episode_wrapper_stats is not None:

--- a/sample_factory/algo/sampling/non_batched_sampling.py
+++ b/sample_factory/algo/sampling/non_batched_sampling.py
@@ -295,8 +295,7 @@ class ActorState:
             episode_extra_stats=info.get("episode_extra_stats", dict()),
         )
 
-        if true_objective := info.get("true_objective", self.last_episode_reward):
-            stats["true_objective"] = true_objective
+        stats["true_objective"] = info.get("true_objective", self.last_episode_reward)
 
         episode_wrapper_stats = record_episode_statistics_wrapper_stats(info)
         if episode_wrapper_stats is not None:

--- a/sample_factory/train.py
+++ b/sample_factory/train.py
@@ -32,7 +32,7 @@ def run_rl(cfg: Config):
     cfg, runner = make_runner(cfg)
 
     # here we can register additional message or summary handlers
-    # see sf_examples/dmlab_examples/train_dmlab.py for example
+    # see sf_examples/dmlab/train_dmlab.py for example
 
     status = runner.init()
     if status == ExperimentStatus.SUCCESS:

--- a/sf_examples/atari/experiments/atari_envs.py
+++ b/sf_examples/atari/experiments/atari_envs.py
@@ -17,11 +17,11 @@ _params = ParamGrid(
 _experiments = [
     Experiment(
         "atari_envs",
-        "python -m sf_examples.atari_examples.train_atari --algo=APPO --with_wandb=True --wandb_project=atari-benchmark --wandb_group=atari_all --wandb_tags run6",
+        "python -m sf_examples.atari.train_atari --algo=APPO --with_wandb=True --wandb_project=atari-benchmark --wandb_group=atari_all --wandb_tags run6",
         _params.generate_params(randomize=False),
     ),
 ]
 
 
 RUN_DESCRIPTION = RunDescription("atari_envs", experiments=_experiments)
-# python -m sample_factory.runner.run --run=sf_examples.atari_examples.experiments.atari_envs --runner=processes --max_parallel=8  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1
+# python -m sample_factory.runner.run --run=sf_examples.atari.experiments.atari_envs --runner=processes --max_parallel=8  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1

--- a/sf_examples/dmlab/experiments/dmlab30.py
+++ b/sf_examples/dmlab/experiments/dmlab30.py
@@ -5,7 +5,7 @@ _params = ParamGrid([("seed", [1111])])
 vstr = "dmlab30"
 
 cli = (
-    "python -m sf_examples.dmlab_examples.train_dmlab "
+    "python -m sf_examples.dmlab.train_dmlab "
     "--env=dmlab_30 "
     "--train_for_seconds=3600000 "
     "--algo=APPO "
@@ -33,5 +33,5 @@ _experiments = [
 RUN_DESCRIPTION = RunDescription(f"{vstr}", experiments=_experiments)
 
 
-# Run locally: python -m sample_factory.runner.run --runner=processes --max_parallel=1 --experiments_per_gpu=1 --num_gpus=1 --run=sf_examples.dmlab_examples.experiments.dmlab30
-# Run on Slurm: python -m sample_factory.runner.run --runner=slurm --slurm_workdir=./slurm_isaacgym --experiment_suffix=slurm --slurm_gpus_per_job=1 --slurm_cpus_per_gpu=16 --slurm_sbatch_template=./sample_factory/runner/slurm/sbatch_template.sh --pause_between=1 --slurm_print_only=False --run=sf_examples.dmlab_examples.experiments.dmlab30
+# Run locally: python -m sample_factory.runner.run --runner=processes --max_parallel=1 --experiments_per_gpu=1 --num_gpus=1 --run=sf_examples.dmlab.experiments.dmlab30
+# Run on Slurm: python -m sample_factory.runner.run --runner=slurm --slurm_workdir=./slurm_isaacgym --experiment_suffix=slurm --slurm_gpus_per_job=1 --slurm_cpus_per_gpu=16 --slurm_sbatch_template=./sample_factory/runner/slurm/sbatch_template.sh --pause_between=1 --slurm_print_only=False --run=sf_examples.dmlab.experiments.dmlab30

--- a/sf_examples/envpool/mujoco/enjoy_envpool_mujoco.py
+++ b/sf_examples/envpool/mujoco/enjoy_envpool_mujoco.py
@@ -1,7 +1,7 @@
 import sys
 
 from sample_factory.enjoy import enjoy
-from sf_examples.mujoco_examples.train_mujoco import parse_mujoco_cfg, register_mujoco_components
+from sf_examples.mujoco.train_mujoco import parse_mujoco_cfg, register_mujoco_components
 
 
 def main():

--- a/sf_examples/mujoco/README.md
+++ b/sf_examples/mujoco/README.md
@@ -5,16 +5,16 @@ or `pip install -e .[mujoco]` in the sample-factory directory.
 
 ## Running Experiments
 
-To run a single experiment, use the `sf_examples.mujoco_examples.train_mujoco` script. An example command is
-`python -m sf_examples.mujoco_examples.train_mujoco --algo=APPO --env=mujoco_ant --experiment=experiment_name`.
+To run a single experiment, use the `sf_examples.mujoco.train_mujoco` script. An example command is
+`python -m sf_examples.mujoco.train_mujoco --algo=APPO --env=mujoco_ant --experiment=experiment_name`.
 
-To run multiple experiments in parallel, use the runner script at `sf_examples.mujoco_examples.experiments.mujoco_all_envs`.
-An example command is `python -m sample_factory.runner.run --run=sf_examples.mujoco_examples.experiments.mujoco_all_envs --runner=processes --max_parallel=4  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1 --experiment_suffix=test`
+To run multiple experiments in parallel, use the runner script at `sf_examples.mujoco.experiments.mujoco_all_envs`.
+An example command is `python -m sample_factory.runner.run --run=sf_examples.mujoco.experiments.mujoco_all_envs --runner=processes --max_parallel=4  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1 --experiment_suffix=test`
 
 ## Showing Experiment Results
 
-To display videos of experiments, use the `sf_examples.mujoco_examples.enjoy_mujoco` script. An example command is 
-`python -m sf_examples.mujoco_examples.enjoy_mujoco --env=mujoco_ant --algo=APPO --experiment=experiment_name`
+To display videos of experiments, use the `sf_examples.mujoco.enjoy_mujoco` script. An example command is 
+`python -m sf_examples.mujoco.enjoy_mujoco --env=mujoco_ant --algo=APPO --experiment=experiment_name`
 
 ## Supported MuJoCo environments
 
@@ -32,7 +32,7 @@ SF2 supports the following MuJoCo v4 environments:
 - mujoco_pusher
 - mujoco_swimmer
 
-More environments can be added in `sf_examples.mujoco_examples.mujoco.mujoco_utils`
+More environments can be added in `sf_examples.mujoco.mujoco_utils`
 
 ## Benchmark Results
 

--- a/sf_examples/mujoco/experiments/mujoco_all_envs.py
+++ b/sf_examples/mujoco/experiments/mujoco_all_envs.py
@@ -23,11 +23,11 @@ _params = ParamGrid(
 _experiments = [
     Experiment(
         "mujoco_all_envs",
-        "python -m sf_examples.mujoco_examples.train_mujoco --algo=APPO --with_wandb=True --wandb_tags mujoco",
+        "python -m sf_examples.mujoco.train_mujoco --algo=APPO --with_wandb=True --wandb_tags mujoco",
         _params.generate_params(randomize=False),
     ),
 ]
 
 
 RUN_DESCRIPTION = RunDescription("mujoco_all_envs", experiments=_experiments)
-# python -m sample_factory.runner.run --run=sf_examples.mujoco_examples.experiments.mujoco_all_envs --runner=processes --max_parallel=4  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1 --experiment_suffix=0
+# python -m sample_factory.runner.run --run=sf_examples.mujoco.experiments.mujoco_all_envs --runner=processes --max_parallel=4  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1 --experiment_suffix=0

--- a/sf_examples/vizdoom/experiments/doom_basic.py
+++ b/sf_examples/vizdoom/experiments/doom_basic.py
@@ -4,7 +4,7 @@ _params = ParamGrid([])
 
 _experiment = Experiment(
     "basic",
-    "python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_basic --train_for_env_steps=3000000 --algo=APPO --env_frameskip=4 --use_rnn=True --wide_aspect_ratio=False --num_workers=20 --num_envs_per_worker=20 --experiment=doom_basic",
+    "python -m sf_examples.vizdoom.train_vizdoom --env=doom_basic --train_for_env_steps=3000000 --algo=APPO --env_frameskip=4 --use_rnn=True --wide_aspect_ratio=False --num_workers=20 --num_envs_per_worker=20 --experiment=doom_basic",
     _params.generate_params(randomize=False),
 )
 

--- a/sf_examples/vizdoom/experiments/doom_battle_battle2_appo.py
+++ b/sf_examples/vizdoom/experiments/doom_battle_battle2_appo.py
@@ -11,7 +11,7 @@ _params = ParamGrid(
 _experiments = [
     Experiment(
         "battle_fs4",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --train_for_env_steps=4000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=16 --num_envs_per_worker=20 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --max_grad_norm=0.0",
+        "python -m sf_examples.vizdoom.train_vizdoom --train_for_env_steps=4000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=16 --num_envs_per_worker=20 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --max_grad_norm=0.0",
         _params.generate_params(randomize=False),
     ),
 ]

--- a/sf_examples/vizdoom/experiments/doom_battle_d4_appo_pbt.py
+++ b/sf_examples/vizdoom/experiments/doom_battle_d4_appo_pbt.py
@@ -9,7 +9,7 @@ _params = ParamGrid(
 _experiments = [
     Experiment(
         "battle_d4_fs4_pbt",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_battle_d4 --train_for_env_steps=50000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --reward_scale=0.5 --num_workers=24 --num_envs_per_worker=30 --num_policies=4 --macro_batch=2048 --batch_size=2048 --wide_aspect_ratio=False --pbt_period_env_steps=5000000",
+        "python -m sf_examples.vizdoom.train_vizdoom --env=doom_battle_d4 --train_for_env_steps=50000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --reward_scale=0.5 --num_workers=24 --num_envs_per_worker=30 --num_policies=4 --macro_batch=2048 --batch_size=2048 --wide_aspect_ratio=False --pbt_period_env_steps=5000000",
         _params.generate_params(randomize=False),
     ),
 ]

--- a/sf_examples/vizdoom/experiments/doom_bots_sweep.py
+++ b/sf_examples/vizdoom/experiments/doom_bots_sweep.py
@@ -9,25 +9,25 @@ _params = ParamGrid(
 _experiments = [
     Experiment(
         "bots_128_fs2_wide",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_dwango5_bots_experimental --train_for_seconds=3600000 --algo=APPO --use_rnn=True --gamma=0.995 --env_frameskip=2 --reward_scale=0.5 --num_workers=18 --num_envs_per_worker=20 --num_policies=1 --macro_batch=2048 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=True",
+        "python -m sf_examples.vizdoom.train_vizdoom --env=doom_dwango5_bots_experimental --train_for_seconds=3600000 --algo=APPO --use_rnn=True --gamma=0.995 --env_frameskip=2 --reward_scale=0.5 --num_workers=18 --num_envs_per_worker=20 --num_policies=1 --macro_batch=2048 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=True",
         _params.generate_params(randomize=False),
         dict(DOOM_DEFAULT_UDP_PORT=35300),
     ),
     Experiment(
         "bots_128_fs2_narrow",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_dwango5_bots_experimental --train_for_seconds=3600000 --algo=APPO --use_rnn=True --gamma=0.995 --env_frameskip=2 --reward_scale=0.5 --num_workers=18 --num_envs_per_worker=20 --num_policies=1 --macro_batch=2048 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=False",
+        "python -m sf_examples.vizdoom.train_vizdoom --env=doom_dwango5_bots_experimental --train_for_seconds=3600000 --algo=APPO --use_rnn=True --gamma=0.995 --env_frameskip=2 --reward_scale=0.5 --num_workers=18 --num_envs_per_worker=20 --num_policies=1 --macro_batch=2048 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=False",
         _params.generate_params(randomize=False),
         dict(DOOM_DEFAULT_UDP_PORT=40300),
     ),
     Experiment(
         "bots_128_fs2_wide_adam0.5",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_dwango5_bots_experimental --train_for_seconds=3600000 --algo=APPO --use_rnn=True --gamma=0.995 --env_frameskip=2 --reward_scale=0.5 --num_workers=18 --num_envs_per_worker=20 --num_policies=1 --macro_batch=2048 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=True --adam_beta1=0.5",
+        "python -m sf_examples.vizdoom.train_vizdoom --env=doom_dwango5_bots_experimental --train_for_seconds=3600000 --algo=APPO --use_rnn=True --gamma=0.995 --env_frameskip=2 --reward_scale=0.5 --num_workers=18 --num_envs_per_worker=20 --num_policies=1 --macro_batch=2048 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=True --adam_beta1=0.5",
         _params.generate_params(randomize=False),
         dict(DOOM_DEFAULT_UDP_PORT=45300),
     ),
     Experiment(
         "bots_128_fs2_narrow_adam0.5",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_dwango5_bots_experimental --train_for_seconds=3600000 --algo=APPO --use_rnn=True --gamma=0.995 --env_frameskip=2 --reward_scale=0.5 --num_workers=18 --num_envs_per_worker=20 --num_policies=1 --macro_batch=2048 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=False --adam_beta1=0.5",
+        "python -m sf_examples.vizdoom.train_vizdoom --env=doom_dwango5_bots_experimental --train_for_seconds=3600000 --algo=APPO --use_rnn=True --gamma=0.995 --env_frameskip=2 --reward_scale=0.5 --num_workers=18 --num_envs_per_worker=20 --num_policies=1 --macro_batch=2048 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=False --adam_beta1=0.5",
         _params.generate_params(randomize=False),
         dict(DOOM_DEFAULT_UDP_PORT=50300),
     ),

--- a/sf_examples/vizdoom/experiments/doom_defend_center.py
+++ b/sf_examples/vizdoom/experiments/doom_defend_center.py
@@ -11,7 +11,7 @@ _params = ParamGrid(
 _experiments = [
     Experiment(
         "basic_envs_fs4",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --train_for_env_steps=100000000 --algo=APPO --env_frameskip=4 --use_rnn=True --rnn_type=lstm --num_workers=72 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --policy_workers_per_policy=3 --experiment_summaries_interval=5 --ppo_clip_value=10.0 --nonlinearity=relu",
+        "python -m sf_examples.vizdoom.train_vizdoom --train_for_env_steps=100000000 --algo=APPO --env_frameskip=4 --use_rnn=True --rnn_type=lstm --num_workers=72 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --policy_workers_per_policy=3 --experiment_summaries_interval=5 --ppo_clip_value=10.0 --nonlinearity=relu",
         _params.generate_params(randomize=False),
     ),
 ]

--- a/sf_examples/vizdoom/experiments/doom_freedm.py
+++ b/sf_examples/vizdoom/experiments/doom_freedm.py
@@ -8,7 +8,7 @@ _params = ParamGrid(
 
 _experiment = Experiment(
     "bots_freedm_fs2",
-    "python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_freedm --train_for_seconds=360000 --algo=APPO --gamma=0.995 --env_frameskip=2 --use_rnn=True --reward_scale=0.5 --num_workers=20 --num_envs_per_worker=4 --num_policies=1 --macro_batch=2048 --batch_size=2048 --benchmark=False --start_bot_difficulty=150",
+    "python -m sf_examples.vizdoom.train_vizdoom --env=doom_freedm --train_for_seconds=360000 --algo=APPO --gamma=0.995 --env_frameskip=2 --use_rnn=True --reward_scale=0.5 --num_workers=20 --num_envs_per_worker=4 --num_policies=1 --macro_batch=2048 --batch_size=2048 --benchmark=False --start_bot_difficulty=150",
     _params.generate_params(randomize=False),
 )
 

--- a/sf_examples/vizdoom/experiments/doom_health_gathering.py
+++ b/sf_examples/vizdoom/experiments/doom_health_gathering.py
@@ -10,12 +10,12 @@ _params = ParamGrid(
 _experiments = [
     Experiment(
         "health_0_255",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --train_for_env_steps=40000000 --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=20 --num_envs_per_worker=12 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False",
+        "python -m sf_examples.vizdoom.train_vizdoom --train_for_env_steps=40000000 --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=20 --num_envs_per_worker=12 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False",
         _params.generate_params(randomize=False),
     ),
     Experiment(
         "health_128_128",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --train_for_env_steps=40000000 --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=20 --num_envs_per_worker=12 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --obs_subtract_mean=128.0 --obs_scale=128.0",
+        "python -m sf_examples.vizdoom.train_vizdoom --train_for_env_steps=40000000 --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=20 --num_envs_per_worker=12 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --obs_subtract_mean=128.0 --obs_scale=128.0",
         _params.generate_params(randomize=False),
     ),
 ]

--- a/sf_examples/vizdoom/experiments/paper_doom_all_basic_envs.py
+++ b/sf_examples/vizdoom/experiments/paper_doom_all_basic_envs.py
@@ -20,7 +20,7 @@ _params = ParamGrid(
 _experiments = [
     Experiment(
         "basic_envs_fs4",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --train_for_env_steps=500000000 --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=36 --num_envs_per_worker=8 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False",
+        "python -m sf_examples.vizdoom.train_vizdoom --train_for_env_steps=500000000 --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=36 --num_envs_per_worker=8 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False",
         _params.generate_params(randomize=False),
     ),
 ]

--- a/sf_examples/vizdoom/experiments/paper_doom_battle2_appo.py
+++ b/sf_examples/vizdoom/experiments/paper_doom_battle2_appo.py
@@ -9,7 +9,7 @@ _params = ParamGrid(
 _experiments = [
     Experiment(
         "battle2_fs4",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_battle2 --train_for_env_steps=3000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --reward_scale=0.5 --num_workers=20 --num_envs_per_worker=20 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False",
+        "python -m sf_examples.vizdoom.train_vizdoom --env=doom_battle2 --train_for_env_steps=3000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --reward_scale=0.5 --num_workers=20 --num_envs_per_worker=20 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False",
         _params.generate_params(randomize=False),
     ),
 ]

--- a/sf_examples/vizdoom/experiments/paper_doom_battle2_appo_pbt.py
+++ b/sf_examples/vizdoom/experiments/paper_doom_battle2_appo_pbt.py
@@ -5,7 +5,7 @@ _params = ParamGrid([])
 _experiments = [
     Experiment(
         "battle2_fs4",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_battle2 --train_for_env_steps=3000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --macro_batch=2048 --batch_size=2048 --wide_aspect_ratio=False --num_workers=72 --num_envs_per_worker=30 --num_policies=8 --with_pbt=True",
+        "python -m sf_examples.vizdoom.train_vizdoom --env=doom_battle2 --train_for_env_steps=3000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --macro_batch=2048 --batch_size=2048 --wide_aspect_ratio=False --num_workers=72 --num_envs_per_worker=30 --num_policies=8 --with_pbt=True",
         _params.generate_params(randomize=False),
     ),
 ]

--- a/sf_examples/vizdoom/experiments/paper_doom_battle_appo.py
+++ b/sf_examples/vizdoom/experiments/paper_doom_battle_appo.py
@@ -9,7 +9,7 @@ _params = ParamGrid(
 _experiments = [
     Experiment(
         "battle_fs4",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_battle --train_for_env_steps=4000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=72 --num_envs_per_worker=8 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --max_grad_norm=0.0",
+        "python -m sf_examples.vizdoom.train_vizdoom --env=doom_battle --train_for_env_steps=4000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=72 --num_envs_per_worker=8 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --max_grad_norm=0.0",
         _params.generate_params(randomize=False),
     ),
 ]

--- a/sf_examples/vizdoom/experiments/paper_doom_battle_appo_pbt.py
+++ b/sf_examples/vizdoom/experiments/paper_doom_battle_appo_pbt.py
@@ -5,7 +5,7 @@ _params = ParamGrid([])
 _experiments = [
     Experiment(
         "battle_fs4",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_battle --train_for_env_steps=4000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --batch_size=2048 --wide_aspect_ratio=False --num_workers=72 --num_envs_per_worker=32 --num_policies=8 --with_pbt=True",
+        "python -m sf_examples.vizdoom.train_vizdoom --env=doom_battle --train_for_env_steps=4000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --batch_size=2048 --wide_aspect_ratio=False --num_workers=72 --num_envs_per_worker=32 --num_policies=8 --with_pbt=True",
         _params.generate_params(randomize=False),
     ),
 ]

--- a/sf_examples/vizdoom/experiments/paper_doom_bots_pbt.py
+++ b/sf_examples/vizdoom/experiments/paper_doom_bots_pbt.py
@@ -9,7 +9,7 @@ _params = ParamGrid(
 _experiments = [
     Experiment(
         "bots_128_fs2_narrow",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_deathmatch_bots --train_for_seconds=3600000 --algo=APPO --use_rnn=True --gamma=0.995 --env_frameskip=2 --num_workers=80 --num_envs_per_worker=24 --num_policies=8 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=False --with_pbt=True --pbt_period_env_steps=5000000",
+        "python -m sf_examples.vizdoom.train_vizdoom --env=doom_deathmatch_bots --train_for_seconds=3600000 --algo=APPO --use_rnn=True --gamma=0.995 --env_frameskip=2 --num_workers=80 --num_envs_per_worker=24 --num_policies=8 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=False --with_pbt=True --pbt_period_env_steps=5000000",
         _params.generate_params(randomize=False),
         dict(DOOM_DEFAULT_UDP_PORT=35300),
     ),

--- a/sf_examples/vizdoom/experiments/paper_doom_duel_bots_pbt.py
+++ b/sf_examples/vizdoom/experiments/paper_doom_duel_bots_pbt.py
@@ -2,7 +2,7 @@ from sample_factory.runner.run_description import Experiment, RunDescription
 
 _experiment = Experiment(
     "bots_ssl2_fs2",
-    "python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_duel_bots --train_for_seconds=360000 --algo=APPO --gamma=0.995 --env_frameskip=2 --use_rnn=True --reward_scale=0.5 --num_workers=72 --num_envs_per_worker=32 --num_policies=8 --batch_size=2048 --benchmark=False --res_w=128 --res_h=72 --wide_aspect_ratio=False --pbt_replace_reward_gap=0.2 --pbt_replace_reward_gap_absolute=3.0 --pbt_period_env_steps=5000000 --save_milestones_sec=1800 --with_pbt=True",
+    "python -m sf_examples.vizdoom.train_vizdoom --env=doom_duel_bots --train_for_seconds=360000 --algo=APPO --gamma=0.995 --env_frameskip=2 --use_rnn=True --reward_scale=0.5 --num_workers=72 --num_envs_per_worker=32 --num_policies=8 --batch_size=2048 --benchmark=False --res_w=128 --res_h=72 --wide_aspect_ratio=False --pbt_replace_reward_gap=0.2 --pbt_replace_reward_gap_absolute=3.0 --pbt_period_env_steps=5000000 --save_milestones_sec=1800 --with_pbt=True",
 )
 
 RUN_DESCRIPTION = RunDescription("paper_doom_duel_bots_fs2", experiments=[_experiment])

--- a/sf_examples/vizdoom/experiments/paper_doom_duel_pbt.py
+++ b/sf_examples/vizdoom/experiments/paper_doom_duel_pbt.py
@@ -2,7 +2,7 @@ from sample_factory.runner.run_description import Experiment, RunDescription
 
 _experiment = Experiment(
     "bots_ssl2_fs2",
-    "python -m sf_examples.vizdoom_examples.train_vizdoom --env=doom_duel --train_for_seconds=360000 --algo=APPO --gamma=0.995 --env_frameskip=2 --use_rnn=True --reward_scale=0.5 --num_workers=72 --num_envs_per_worker=16 --num_policies=8 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=False --benchmark=False --pbt_replace_reward_gap=0.5 --pbt_replace_reward_gap_absolute=0.35 --pbt_period_env_steps=5000000 --with_pbt=True --pbt_start_mutation=100000000",
+    "python -m sf_examples.vizdoom.train_vizdoom --env=doom_duel --train_for_seconds=360000 --algo=APPO --gamma=0.995 --env_frameskip=2 --use_rnn=True --reward_scale=0.5 --num_workers=72 --num_envs_per_worker=16 --num_policies=8 --batch_size=2048 --res_w=128 --res_h=72 --wide_aspect_ratio=False --benchmark=False --pbt_replace_reward_gap=0.5 --pbt_replace_reward_gap_absolute=0.35 --pbt_period_env_steps=5000000 --with_pbt=True --pbt_start_mutation=100000000",
 )
 
 RUN_DESCRIPTION = RunDescription("paper_doom_duel_fs2", experiments=[_experiment])

--- a/sf_examples/vizdoom/experiments/paper_doom_wall_time.py
+++ b/sf_examples/vizdoom/experiments/paper_doom_wall_time.py
@@ -11,7 +11,7 @@ _params = ParamGrid(
 _experiments = [
     Experiment(
         "basic_envs_fs4",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --train_for_env_steps=100000000 --algo=APPO --env_frameskip=4 --use_rnn=True --rnn_type=lstm --num_workers=72 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --policy_workers_per_policy=3 --experiment_summaries_interval=5 --ppo_clip_value=10.0 --nonlinearity=relu",
+        "python -m sf_examples.vizdoom.train_vizdoom --train_for_env_steps=100000000 --algo=APPO --env_frameskip=4 --use_rnn=True --rnn_type=lstm --num_workers=72 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --policy_workers_per_policy=3 --experiment_summaries_interval=5 --ppo_clip_value=10.0 --nonlinearity=relu",
         _params.generate_params(randomize=False),
     ),
 ]

--- a/sf_examples/vizdoom/experiments/sf2_doom_battle_envs.py
+++ b/sf_examples/vizdoom/experiments/sf2_doom_battle_envs.py
@@ -11,7 +11,7 @@ _params = ParamGrid(
 _experiments = [
     Experiment(
         "sf2_doom_battle_envs",
-        "python -m sf_examples.vizdoom_examples.train_vizdoom --train_for_env_steps=4000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=16 --num_envs_per_worker=20 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --max_grad_norm=0.0 --normalize_input=True",
+        "python -m sf_examples.vizdoom.train_vizdoom --train_for_env_steps=4000000000 --algo=APPO --env_frameskip=4 --use_rnn=True --num_workers=16 --num_envs_per_worker=20 --num_policies=1 --batch_size=2048 --wide_aspect_ratio=False --max_grad_norm=0.0 --normalize_input=True",
         _params.generate_params(randomize=False),
     ),
 ]

--- a/sf_examples/vizdoom/train_custom_vizdoom_env.py
+++ b/sf_examples/vizdoom/train_custom_vizdoom_env.py
@@ -2,10 +2,10 @@
 Example of how to use VizDoom env API to use your own custom VizDoom environment with Sample Factory.
 
 To train:
-python -m sf_examples.vizdoom_examples.train_custom_vizdoom_env --algo=APPO --env=doom_my_custom_env --experiment=doom_my_custom_env_example --save_every_sec=5 --experiment_summaries_interval=10
+python -m sf_examples.vizdoom.train_custom_vizdoom_env --algo=APPO --env=doom_my_custom_env --experiment=doom_my_custom_env_example --save_every_sec=5 --experiment_summaries_interval=10
 
 After training for a desired period of time, evaluate the policy by running:
-python -m sf_examples.vizdoom_examples.enjoy_custom_vizdoom_env --algo=APPO --env=doom_my_custom_env --experiment=doom_my_custom_env_example
+python -m sf_examples.vizdoom.enjoy_custom_vizdoom_env --algo=APPO --env=doom_my_custom_env --experiment=doom_my_custom_env_example
 
 """
 import argparse


### PR DESCRIPTION
Fixed _episodic_stats for doom_duel_pbt

Also updated `sf_examples.*_examples` to `sf_examples.*` in runner scripts and readmes for mujoco, vizdoom, atari, and dmlab after envpool folder changes. (isaac_gym is still in isaac_gym_examples, do we want to change that too for consistency?)