### PR TITLE
Envpool mujoco tuning

### DIFF
--- a/sample_factory/algo/runners/runner.py
+++ b/sample_factory/algo/runners/runner.py
@@ -757,6 +757,9 @@ class Runner(EventLoopObject, Configurable):
         for component, profile in self.component_profiles:
             log.info(profile)
 
+        for w in self.writers.values():
+            w.flush()
+
         assert self.event_loop.owner is self
         self.event_loop.stop()
 

--- a/sample_factory/utils/algo_version.py
+++ b/sample_factory/utils/algo_version.py
@@ -1,0 +1,3 @@
+# Bump this every time theres a significant change in the algorithm that can affect sample efficiency or performance
+# SF1 was up to ~125, we reset this to 1 again for SF2 in April/May 2022
+ALGO_VERSION = 80

--- a/sample_factory/utils/wandb_utils.py
+++ b/sample_factory/utils/wandb_utils.py
@@ -42,7 +42,7 @@ def init_wandb(cfg):
             group=wandb_group,
             job_type=cfg.wandb_job_type,
             tags=cfg.wandb_tags,
-            resume=True,
+            resume="allow",
             settings=wandb.Settings(start_method="fork"),
         )
 

--- a/sf_examples/envpool/envpool_utils.py
+++ b/sf_examples/envpool/envpool_utils.py
@@ -1,5 +1,23 @@
+import multiprocessing
+
 from sample_factory.utils.utils import is_module_available
 
 
 def envpool_available():
     return is_module_available("envpool")
+
+
+def add_envpool_common_args(env, parser) -> None:
+    parser.add_argument(
+        "--envpool_num_threads",
+        default=multiprocessing.cpu_count(),
+        type=int,
+        help="Num threads to use for envpool, defaults to the number of logical CPUs",
+    )
+
+    parser.add_argument(
+        "--envpool_thread_affinity_offset",
+        default=0,
+        type=int,
+        help="The start id of binding thread. -1 means not to use thread affinity in thread pool. More information: https://envpool.readthedocs.io/en/latest/content/python_interface.html",
+    )

--- a/sf_examples/envpool/mujoco/enjoy_envpool_mujoco.py
+++ b/sf_examples/envpool/mujoco/enjoy_envpool_mujoco.py
@@ -5,7 +5,6 @@ from sf_examples.mujoco.train_mujoco import parse_mujoco_cfg, register_mujoco_co
 
 
 def main():
-    """Script entry point."""
     register_mujoco_components()
     cfg = parse_mujoco_cfg(evaluation=True)
     status = enjoy(cfg)

--- a/sf_examples/envpool/mujoco/envpool_mujoco_params.py
+++ b/sf_examples/envpool/mujoco/envpool_mujoco_params.py
@@ -1,5 +1,7 @@
 import argparse
 
+from sf_examples.envpool.envpool_utils import add_envpool_common_args
+
 
 def mujoco_envpool_override_defaults(env: str, parser: argparse.ArgumentParser) -> None:
     # High-throughput parameters optimized for wall-time performance (e.g. getting the highest reward in 10 minutes).
@@ -55,3 +57,5 @@ def add_mujoco_envpool_env_args(env, parser, evaluation: bool = False) -> None:
         type=int,
         help="Num agents in each envpool (if used)",
     )
+
+    add_envpool_common_args(env, parser)

--- a/sf_examples/envpool/mujoco/envpool_mujoco_params.py
+++ b/sf_examples/envpool/mujoco/envpool_mujoco_params.py
@@ -8,28 +8,28 @@ def mujoco_envpool_override_defaults(env: str, parser: argparse.ArgumentParser) 
 
     parser.set_defaults(
         batched_sampling=True,
-        num_workers=8,
-        num_envs_per_worker=1,
-        worker_num_splits=1,
+        num_workers=1,  # envpool takes care of parallelization, so use only 1 worker?
+        num_envs_per_worker=1,  # two envs per worker for double-buffered sampling
+        worker_num_splits=1,  # enable double-buffered sampling (step one whole envpool at a time)
         train_for_env_steps=10000000,
-        encoder_mlp_layers=[64, 64],
-        env_frameskip=1,
-        nonlinearity="tanh",
-        batch_size=1024,
-        kl_loss_coeff=0.1,
+        encoder_mlp_layers=[256, 128, 64],
+        nonlinearity="elu",  # as in https://github.com/Denys88/rl_games/blob/d8645b2678c0d8a6e98a6e3f2b17f0ecfbff71ad/rl_games/configs/mujoco/ant_envpool.yaml#L24
+        kl_loss_coeff=0.01,
         use_rnn=False,
         adaptive_stddev=False,
         policy_initialization="torch_default",
-        reward_scale=1,
+        reward_scale=0.1,
         rollout=64,
-        max_grad_norm=3.5,
-        num_epochs=2,
-        num_batches_per_epoch=4,
+        max_grad_norm=1.0,
+        num_epochs=4,
+        num_batches_per_epoch=2,
+        batch_size=2048,  # 2048 * 2 = 4096 env steps per training iteration
         ppo_clip_ratio=0.2,
-        value_loss_coeff=1.3,
+        value_loss_coeff=2.0,
         exploration_loss_coeff=0.0,
-        learning_rate=0.00295,
-        lr_schedule="linear_decay",
+        learning_rate=3e-4,
+        lr_schedule="kl_adaptive_epoch",
+        lr_schedule_kl_threshold=0.008,
         shuffle_minibatches=False,
         gamma=0.99,
         gae_lambda=0.95,
@@ -37,19 +37,20 @@ def mujoco_envpool_override_defaults(env: str, parser: argparse.ArgumentParser) 
         recurrence=1,
         normalize_input=True,
         normalize_returns=True,
+        value_bootstrap=True,
         experiment_summaries_interval=3,
         save_every_sec=15,
-        serial_mode=False,
+        serial_mode=True,  # we're running with 1 worker in sync mode, so might as well run everything in one process
         async_rl=False,
     )
 
 
 # noinspection PyUnusedLocal
-def add_mujoco_envpool_env_args(env, parser):
+def add_mujoco_envpool_env_args(env, parser, evaluation: bool = False) -> None:
     # in case we need to add more args in the future
     parser.add_argument(
         "--env_agents",
-        default=8,
+        default=1 if evaluation else 64,
         type=int,
         help="Num agents in each envpool (if used)",
     )

--- a/sf_examples/envpool/mujoco/envpool_mujoco_params.py
+++ b/sf_examples/envpool/mujoco/envpool_mujoco_params.py
@@ -1,16 +1,16 @@
 import argparse
 
 
-def mujoco_override_defaults(env: str, parser: argparse.ArgumentParser) -> None:
+def mujoco_envpool_override_defaults(env: str, parser: argparse.ArgumentParser) -> None:
     # High-throughput parameters.
     # See sf_examples/mujoco/mujoco_params.py for more standard parameters similar to SB3/CleanRL that are known
     # to provide good sample efficiency
 
     parser.set_defaults(
-        batched_sampling=False,
+        batched_sampling=True,
         num_workers=8,
-        num_envs_per_worker=8,
-        worker_num_splits=2,
+        num_envs_per_worker=1,
+        worker_num_splits=1,
         train_for_env_steps=10000000,
         encoder_mlp_layers=[64, 64],
         env_frameskip=1,
@@ -45,11 +45,11 @@ def mujoco_override_defaults(env: str, parser: argparse.ArgumentParser) -> None:
 
 
 # noinspection PyUnusedLocal
-def add_mujoco_env_args(env, parser):
+def add_mujoco_envpool_env_args(env, parser):
     # in case we need to add more args in the future
     parser.add_argument(
         "--env_agents",
-        default=2,
+        default=8,
         type=int,
         help="Num agents in each envpool (if used)",
     )

--- a/sf_examples/envpool/mujoco/envpool_mujoco_params.py
+++ b/sf_examples/envpool/mujoco/envpool_mujoco_params.py
@@ -9,8 +9,8 @@ def mujoco_envpool_override_defaults(env: str, parser: argparse.ArgumentParser) 
     parser.set_defaults(
         batched_sampling=True,
         num_workers=1,  # envpool takes care of parallelization, so use only 1 worker?
-        num_envs_per_worker=1,  # two envs per worker for double-buffered sampling
-        worker_num_splits=1,  # enable double-buffered sampling (step one whole envpool at a time)
+        num_envs_per_worker=1,  # two envs per worker for double-buffered sampling, one for single-buffered
+        worker_num_splits=1,  # change to 2 to enable double-buffered sampling
         train_for_env_steps=10000000,
         encoder_mlp_layers=[256, 128, 64],
         nonlinearity="elu",  # as in https://github.com/Denys88/rl_games/blob/d8645b2678c0d8a6e98a6e3f2b17f0ecfbff71ad/rl_games/configs/mujoco/ant_envpool.yaml#L24
@@ -40,8 +40,8 @@ def mujoco_envpool_override_defaults(env: str, parser: argparse.ArgumentParser) 
         value_bootstrap=True,
         experiment_summaries_interval=3,
         save_every_sec=15,
-        serial_mode=True,  # we're running with 1 worker in sync mode, so might as well run everything in one process
         async_rl=False,
+        serial_mode=True,  # we're running with 1 worker in sync mode, so might as well run everything in one process
     )
 
 

--- a/sf_examples/envpool/mujoco/envpool_mujoco_params.py
+++ b/sf_examples/envpool/mujoco/envpool_mujoco_params.py
@@ -2,7 +2,7 @@ import argparse
 
 
 def mujoco_envpool_override_defaults(env: str, parser: argparse.ArgumentParser) -> None:
-    # High-throughput parameters.
+    # High-throughput parameters optimized for wall-time performance (e.g. getting the highest reward in 10 minutes).
     # See sf_examples/mujoco/mujoco_params.py for more standard parameters similar to SB3/CleanRL that are known
     # to provide good sample efficiency
 
@@ -38,8 +38,9 @@ def mujoco_envpool_override_defaults(env: str, parser: argparse.ArgumentParser) 
         normalize_input=True,
         normalize_returns=True,
         value_bootstrap=True,
-        experiment_summaries_interval=3,
+        experiment_summaries_interval=15,
         save_every_sec=15,
+        save_best_every_sec=15,
         async_rl=False,
         serial_mode=True,  # we're running with 1 worker in sync mode, so might as well run everything in one process
     )

--- a/sf_examples/envpool/mujoco/envpool_mujoco_params.py
+++ b/sf_examples/envpool/mujoco/envpool_mujoco_params.py
@@ -14,7 +14,7 @@ def mujoco_envpool_override_defaults(env: str, parser: argparse.ArgumentParser) 
         train_for_env_steps=10000000,
         encoder_mlp_layers=[256, 128, 64],
         nonlinearity="elu",  # as in https://github.com/Denys88/rl_games/blob/d8645b2678c0d8a6e98a6e3f2b17f0ecfbff71ad/rl_games/configs/mujoco/ant_envpool.yaml#L24
-        kl_loss_coeff=0.01,
+        kl_loss_coeff=0.1,
         use_rnn=False,
         adaptive_stddev=False,
         policy_initialization="torch_default",
@@ -22,12 +22,12 @@ def mujoco_envpool_override_defaults(env: str, parser: argparse.ArgumentParser) 
         rollout=64,
         max_grad_norm=1.0,
         num_epochs=4,
-        num_batches_per_epoch=2,
-        batch_size=2048,  # 2048 * 2 = 4096 env steps per training iteration
+        num_batches_per_epoch=4,
+        batch_size=2048,  # 2048 * 4 = 8192 env steps per training iteration
         ppo_clip_ratio=0.2,
         value_loss_coeff=2.0,
         exploration_loss_coeff=0.0,
-        learning_rate=3e-4,
+        learning_rate=3e-4,  # does not matter because it will be adaptively changed anyway
         lr_schedule="kl_adaptive_epoch",
         lr_schedule_kl_threshold=0.008,
         shuffle_minibatches=False,
@@ -50,7 +50,7 @@ def add_mujoco_envpool_env_args(env, parser, evaluation: bool = False) -> None:
     # in case we need to add more args in the future
     parser.add_argument(
         "--env_agents",
-        default=1 if evaluation else 64,
+        default=1 if evaluation else 128,
         type=int,
         help="Num agents in each envpool (if used)",
     )

--- a/sf_examples/envpool/mujoco/envpool_mujoco_params.py
+++ b/sf_examples/envpool/mujoco/envpool_mujoco_params.py
@@ -1,4 +1,11 @@
-def mujoco_override_defaults(env, parser):
+import argparse
+
+
+def mujoco_override_defaults(env: str, parser: argparse.ArgumentParser) -> None:
+    # High-throughput parameters.
+    # See sf_examples/mujoco/mujoco_params.py for more standard parameters similar to SB3/CleanRL that are known
+    # to provide good sample efficiency
+
     parser.set_defaults(
         batched_sampling=False,
         num_workers=8,

--- a/sf_examples/envpool/mujoco/envpool_mujoco_utils.py
+++ b/sf_examples/envpool/mujoco/envpool_mujoco_utils.py
@@ -5,6 +5,7 @@ try:
 except ImportError as e:
     print(e)
     print("Trying to import envpool when it is not install. install with 'pip install envpool'")
+    raise e
 
 
 from sf_examples.envpool.envpool_wrappers import EnvPoolResetFixWrapper
@@ -20,7 +21,7 @@ def mujoco_env_by_name(name):
 
 def make_mujoco_env(env_name, cfg, env_config, render_mode: Optional[str] = None, **kwargs):
     assert cfg.batched_sampling, "batched sampling must be used when using envpool"
-    assert cfg.num_envs_per_worker == 1, "when using envpool, set num_envs_per_worker=1 and use --env_agents="
+    # assert cfg.num_envs_per_worker == 1, "when using envpool, set num_envs_per_worker=1 and use --env_agents="
     mujoco_spec = mujoco_env_by_name(env_name)
     env_kwargs = dict()
     if env_config is not None:

--- a/sf_examples/envpool/mujoco/experiments/mujoco_envpool.py
+++ b/sf_examples/envpool/mujoco/experiments/mujoco_envpool.py
@@ -3,7 +3,7 @@ from sample_factory.utils.algo_version import ALGO_VERSION
 
 _params = ParamGrid(
     [
-        ("seed", 00, 11, 22),
+        ("seed", [00, 11, 22]),
         ("env", ["mujoco_ant", "mujoco_humanoid", "mujoco_halfcheetah", "mujoco_hopper"]),
     ]
 )

--- a/sf_examples/envpool/mujoco/experiments/mujoco_envpool.py
+++ b/sf_examples/envpool/mujoco/experiments/mujoco_envpool.py
@@ -1,10 +1,9 @@
-from sample_factory.launcher.launcher_utils import seeds
 from sample_factory.launcher.run_description import Experiment, ParamGrid, RunDescription
 from sample_factory.utils.algo_version import ALGO_VERSION
 
 _params = ParamGrid(
     [
-        ("seed", seeds(3)),
+        ("seed", 00, 11, 22),
         ("env", ["mujoco_ant", "mujoco_humanoid", "mujoco_halfcheetah", "mujoco_hopper"]),
     ]
 )

--- a/sf_examples/envpool/mujoco/experiments/mujoco_envpool.py
+++ b/sf_examples/envpool/mujoco/experiments/mujoco_envpool.py
@@ -1,0 +1,22 @@
+from sample_factory.launcher.launcher_utils import seeds
+from sample_factory.launcher.run_description import Experiment, ParamGrid, RunDescription
+from sample_factory.utils.algo_version import ALGO_VERSION
+
+_params = ParamGrid(
+    [
+        ("seed", seeds(3)),
+        ("env", ["mujoco_ant", "mujoco_humanoid", "mujoco_halfcheetah", "mujoco_hopper"]),
+    ]
+)
+
+vstr = f"mujoco_envpool_baseline_v{ALGO_VERSION}"
+cli = (
+    f"python -m sf_examples.envpool.mujoco.train_envpool_mujoco "
+    f"--train_for_env_steps=10000000 --with_wandb=True --wandb_tags {vstr} --wandb_group=sf2_{vstr}"
+)
+
+_experiments = [Experiment(f"{vstr}", cli, _params.generate_params(False))]
+RUN_DESCRIPTION = RunDescription(f"{vstr}", experiments=_experiments)
+
+# Run locally: python -m sample_factory.launcher.run --run=sf_examples.envpool.mujoco.experiments.mujoco_envpool --backend=processes --max_parallel=2 --experiments_per_gpu=2 --num_gpus=1
+# Run on Slurm: python -m sample_factory.launcher.run --run=sf_examples.envpool.mujoco.experiments.mujoco_envpool --backend=slurm --slurm_workdir=./slurm_isaacgym --experiment_suffix=slurm --slurm_gpus_per_job=1 --slurm_cpus_per_gpu=16 --slurm_sbatch_template=./sample_factory/launcher/slurm/sbatch_timeout.sh --pause_between=1 --slurm_print_only=False

--- a/sf_examples/envpool/mujoco/experiments/mujoco_envpool.py
+++ b/sf_examples/envpool/mujoco/experiments/mujoco_envpool.py
@@ -4,11 +4,24 @@ from sample_factory.utils.algo_version import ALGO_VERSION
 _params = ParamGrid(
     [
         ("seed", [00, 11, 22]),
-        ("env", ["mujoco_ant", "mujoco_humanoid", "mujoco_halfcheetah", "mujoco_hopper"]),
+        (
+            "env",
+            [
+                "mujoco_ant",
+                "mujoco_halfcheetah",
+                "mujoco_hopper",
+                "mujoco_humanoid",
+                "mujoco_doublependulum",
+                "mujoco_pendulum",
+                "mujoco_reacher",
+                "mujoco_swimmer",
+                "mujoco_walker",
+            ],
+        ),
     ]
 )
 
-vstr = f"mujoco_envpool_baseline_v{ALGO_VERSION}"
+vstr = f"mujoco_envpool_v{ALGO_VERSION}"
 cli = (
     f"python -m sf_examples.envpool.mujoco.train_envpool_mujoco "
     f"--train_for_env_steps=10000000 --with_wandb=True --wandb_tags {vstr} --wandb_group=sf2_{vstr}"

--- a/sf_examples/envpool/mujoco/experiments/mujoco_envpool.py
+++ b/sf_examples/envpool/mujoco/experiments/mujoco_envpool.py
@@ -24,7 +24,7 @@ _params = ParamGrid(
 vstr = f"mujoco_envpool_v{ALGO_VERSION}"
 cli = (
     f"python -m sf_examples.envpool.mujoco.train_envpool_mujoco "
-    f"--train_for_env_steps=10000000 --with_wandb=True --wandb_tags {vstr} --wandb_group=sf2_{vstr}"
+    f"--train_for_env_steps=100000000 --with_wandb=True --wandb_tags {vstr} --wandb_group=sf2_{vstr}"
 )
 
 _experiments = [Experiment(f"{vstr}", cli, _params.generate_params(False))]

--- a/sf_examples/envpool/mujoco/train_envpool_mujoco.py
+++ b/sf_examples/envpool/mujoco/train_envpool_mujoco.py
@@ -4,7 +4,10 @@ from sample_factory.cfg.arguments import parse_full_cfg, parse_sf_args
 from sample_factory.envs.env_utils import register_env
 from sample_factory.train import run_rl
 from sample_factory.utils.typing import Config
-from sf_examples.envpool.mujoco.envpool_mujoco_params import add_mujoco_env_args, mujoco_override_defaults
+from sf_examples.envpool.mujoco.envpool_mujoco_params import (
+    add_mujoco_envpool_env_args,
+    mujoco_envpool_override_defaults,
+)
 from sf_examples.envpool.mujoco.envpool_mujoco_utils import make_mujoco_env
 from sf_examples.mujoco.mujoco_utils import MUJOCO_ENVS
 
@@ -16,8 +19,8 @@ def register_mujoco_components():
 
 def parse_mujoco_cfg(argv=None, evaluation: bool = False) -> Config:
     parser, partial_cfg = parse_sf_args(argv=argv, evaluation=evaluation)
-    add_mujoco_env_args(partial_cfg.env, parser)
-    mujoco_override_defaults(partial_cfg.env, parser)
+    add_mujoco_envpool_env_args(partial_cfg.env, parser)
+    mujoco_envpool_override_defaults(partial_cfg.env, parser)
     final_cfg = parse_full_cfg(parser, argv)
     return final_cfg
 

--- a/sf_examples/envpool/mujoco/train_envpool_mujoco.py
+++ b/sf_examples/envpool/mujoco/train_envpool_mujoco.py
@@ -3,6 +3,7 @@ import sys
 from sample_factory.cfg.arguments import parse_full_cfg, parse_sf_args
 from sample_factory.envs.env_utils import register_env
 from sample_factory.train import run_rl
+from sample_factory.utils.typing import Config
 from sf_examples.envpool.mujoco.envpool_mujoco_params import add_mujoco_env_args, mujoco_override_defaults
 from sf_examples.envpool.mujoco.envpool_mujoco_utils import make_mujoco_env
 from sf_examples.mujoco.mujoco_utils import MUJOCO_ENVS
@@ -13,7 +14,7 @@ def register_mujoco_components():
         register_env(env.name, make_mujoco_env)
 
 
-def parse_mujoco_cfg(argv=None, evaluation=False):
+def parse_mujoco_cfg(argv=None, evaluation: bool = False) -> Config:
     parser, partial_cfg = parse_sf_args(argv=argv, evaluation=evaluation)
     add_mujoco_env_args(partial_cfg.env, parser)
     mujoco_override_defaults(partial_cfg.env, parser)

--- a/sf_examples/envpool/mujoco/train_envpool_mujoco.py
+++ b/sf_examples/envpool/mujoco/train_envpool_mujoco.py
@@ -19,14 +19,13 @@ def register_mujoco_components():
 
 def parse_mujoco_cfg(argv=None, evaluation: bool = False) -> Config:
     parser, partial_cfg = parse_sf_args(argv=argv, evaluation=evaluation)
-    add_mujoco_envpool_env_args(partial_cfg.env, parser)
+    add_mujoco_envpool_env_args(partial_cfg.env, parser, evaluation)
     mujoco_envpool_override_defaults(partial_cfg.env, parser)
     final_cfg = parse_full_cfg(parser, argv)
     return final_cfg
 
 
 def main():
-    """Script entry point."""
     register_mujoco_components()
     cfg = parse_mujoco_cfg()
     status = run_rl(cfg)

--- a/sf_examples/isaacgym_examples/experiments/isaacgym_runs.py
+++ b/sf_examples/isaacgym_examples/experiments/isaacgym_runs.py
@@ -1,4 +1,6 @@
-version = 79
+from sample_factory.utils.algo_version import ALGO_VERSION
+
+version = ALGO_VERSION
 vstr = f"v{version:03d}"
 
 # wandb_project = 'rlgpu-2022'

--- a/sf_examples/mujoco/mujoco_params.py
+++ b/sf_examples/mujoco/mujoco_params.py
@@ -30,6 +30,7 @@ def mujoco_override_defaults(env, parser):
         recurrence=1,
         normalize_input=True,
         normalize_returns=True,
+        value_bootstrap=True,
         experiment_summaries_interval=3,
         save_every_sec=15,
         serial_mode=False,

--- a/tests/envs/mujoco/test_envpool_mujoco.py
+++ b/tests/envs/mujoco/test_envpool_mujoco.py
@@ -9,7 +9,6 @@ from sample_factory.train import make_runner
 from sample_factory.utils.typing import Config
 from sample_factory.utils.utils import log
 from sf_examples.envpool.envpool_utils import envpool_available
-from sf_examples.envpool.mujoco.train_envpool_mujoco import parse_mujoco_cfg, register_mujoco_components
 from sf_examples.mujoco.mujoco_utils import mujoco_available
 from tests.utils import clean_test_dir
 
@@ -19,6 +18,8 @@ from tests.utils import clean_test_dir
 class TestEnvpoolMujoco:
     @pytest.fixture(scope="class", autouse=True)
     def register_mujoco_fixture(self):
+        from sf_examples.envpool.mujoco.train_envpool_mujoco import register_mujoco_components
+
         register_mujoco_components()
 
     @staticmethod
@@ -38,6 +39,8 @@ class TestEnvpoolMujoco:
         assert train_steps > batch_size, "We need sufficient number of steps to accumulate at least one batch"
 
         experiment_name = f"test_envpool_{num_workers}_{env}"
+
+        from sf_examples.envpool.mujoco.train_envpool_mujoco import parse_mujoco_cfg
 
         cfg = parse_mujoco_cfg(argv=["--algo=APPO", f"--env={env}", f"--experiment={experiment_name}"])
         cfg.serial_mode = serial_mode


### PR DESCRIPTION
@edbeeching I updated some parameters to be more inline with https://github.com/Denys88/rl_games/blob/master/docs/MUJOCO_ENVPOOL.md and I think the performance is substantially better (both sample efficiency and throughput). Please let me know what you think!

Both rl_games and our config use only 64 agents which is really quite a small number (in IGE we use 4K-8K). I tried playing with params a bit more (more agents, larger batch, shorter rollout), and I can easily get same wall-time performance (so better FPS but worse sample efficiency), but with configs I tried I could not get better wall-time reward than this baseline config.

I also noticed that one some seeds the result is a bit worse than rl_games (on Ant I got ~5000 reward at 5M and rl_games is ~6000 reward). This can be addressed later. Should be a good task for @andrewzhang505 to figure this out in the future.