### PR TITLE
Sf2 cfg docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - sf2
+      - sf2-cfg-docs
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -10,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.x
+          python-version: 3.8
       - name: install dependencies
         run: |
           pip install mkdocs-material
@@ -19,5 +20,8 @@ jobs:
           pip install mkdocs-git-revision-date-localized-plugin
           pip install mkdocs-git-committers-plugin-2
           pip install mkdocs-git-authors-plugin
+          pip install -e .
+      - name: generate config params doc
+        run: bash ./docs/cfg-params.sh
       - name: deploy the website
         run: mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - sf2
-      - sf2-cfg-docs
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/docs/cfg-params.sh
+++ b/docs/cfg-params.sh
@@ -1,0 +1,18 @@
+#!/bin/bash 
+
+FILE=docs/get-started/cfg-params.md
+
+cat << EOF > $FILE
+# Configuration Parameters
+## Training Parameters
+The command line arguments / config parameters for training using Sample Factory can be found by running your training script with the \`--help\` flag. 
+The list of config parameters below was obtained from running \`python -m sf_examples.train_gym_env --env=CartPole-v1 --help\`. These params can be used in any environment.
+Other environments may have other custom params than can be viewed with \`--help\`
+\`\`\`
+EOF
+
+python -m sf_examples.train_gym_env --env=CartPole-v1 --help >> $FILE
+
+cat << EOF >> $FILE
+\`\`\`
+EOF 

--- a/docs/cfg-params.sh
+++ b/docs/cfg-params.sh
@@ -8,11 +8,10 @@ cat << EOF > $FILE
 The command line arguments / config parameters for training using Sample Factory can be found by running your training script with the \`--help\` flag. 
 The list of config parameters below was obtained from running \`python -m sf_examples.train_gym_env --env=CartPole-v1 --help\`. These params can be used in any environment.
 Other environments may have other custom params than can be viewed with \`--help\`
+
 \`\`\`
 EOF
 
 python -m sf_examples.train_gym_env --env=CartPole-v1 --help >> $FILE
 
-cat << EOF >> $FILE
-\`\`\`
-EOF 
+echo \`\`\` >> $FILE

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
     - get-started/basic-usage.md
     - get-started/running-experiments.md
     - get-started/customizing.md
+    - get-started/cfg-params.sh
     - get-started/running-slurm.md
     - get-started/experiment-launcher.md
     - get-started/huggingface.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,7 +124,7 @@ nav:
     - get-started/basic-usage.md
     - get-started/running-experiments.md
     - get-started/customizing.md
-    - get-started/cfg-params.sh
+    - get-started/cfg-params.md
     - get-started/running-slurm.md
     - get-started/experiment-launcher.md
     - get-started/huggingface.md


### PR DESCRIPTION
Automatic generation of page for documenting cfg parameters. Example of how the page looks here: https://andrewzhang505.github.io/sample-factory/get-started/cfg-params/