### PR TITLE
Launcher docs fix

### DIFF
--- a/docs/environment-integrations/atari.md
+++ b/docs/environment-integrations/atari.md
@@ -29,10 +29,10 @@ To visualize the training results, use the `enjoy_atari` script:
 python -m sf_examples.atari.enjoy_atari --algo=APPO --env=atari_breakout --experiment="Experiment Name"
 ```
 
-Multiple experiments can be run in parallel with the runner module. `atari_envs` is an example runner script that runs atari envs with 4 seeds. 
+Multiple experiments can be run in parallel with the launcher module. `atari_envs` is an example launcher script that runs atari envs with 4 seeds. 
 
 ```
-python -m sample_factory.launcher.run --run=sf_examples.atari.experiments.atari_envs --runner=processes --max_parallel=8  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1
+python -m sample_factory.launcher.run --run=sf_examples.atari.experiments.atari_envs --backend=processes --max_parallel=8  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1
 ```
 
 ### List of Supported Environments

--- a/docs/environment-integrations/dmlab.md
+++ b/docs/environment-integrations/dmlab.md
@@ -14,7 +14,7 @@ Command lines for running experiments with these datasets are provided in the se
 
 ### Running Experiments
 
-Run DMLab experiments with the scripts in `sf_examples.dmlab_examples`. 
+Run DMLab experiments with the scripts in `sf_examples.dmlab`. 
 
 Example of training in the DMLab watermaze environment for 1B environment steps
 

--- a/docs/environment-integrations/envpool.md
+++ b/docs/environment-integrations/envpool.md
@@ -26,8 +26,8 @@ To visualize the training results, use the `enjoy_atari` script:
 python -m sf_examples.atari.enjoy_atari --algo=APPO --env=atari_breakout --experiment="Experiment Name"
 ```
 
-Multiple experiments can be run in parallel with the runner module. `atari_envs` is an example runner script that runs atari envs with 4 seeds. 
+Multiple experiments can be run in parallel with the launcher module. `atari_envs` is an example launcher script that runs atari envs with 4 seeds. 
 
 ```
-python -m sample_factory.launcher.run --run=sf_examples.envpool.atari.experiments.atari_envs --runner=processes --max_parallel=8  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1
+python -m sample_factory.launcher.run --run=sf_examples.envpool.atari.experiments.atari_envs --backend=processes --max_parallel=8  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1
 ```

--- a/docs/environment-integrations/megaverse.md
+++ b/docs/environment-integrations/megaverse.md
@@ -28,16 +28,16 @@ To visualize the training results, use the `enjoy_megaverse` script:
 python -m megaverse_rl.enjoy_megaverse --algo=APPO --env=TowerBuilding --experiment=TowerBuilding --megaverse_num_envs_per_instance=1 --fps=20 --megaverse_use_vulkan=True
 ```
 
-Multiple experiments can be run in parallel with the runner module. `megaverse_envs` is an example runner script that runs atari envs with 4 seeds. 
+Multiple experiments can be run in parallel with the launcher module. `megaverse_envs` is an example launcher script that runs atari envs with 4 seeds. 
 
 ```
-python -m sample_factory.launcher.run --run=megaverse_rl.runs.single_agent --runner=processes --max_parallel=2  --pause_between=1 --experiments_per_gpu=2 --num_gpus=1
+python -m sample_factory.launcher.run --run=megaverse_rl.runs.single_agent --backend=processes --max_parallel=2  --pause_between=1 --experiments_per_gpu=2 --num_gpus=1
 ```
 
 Or you could run experiments on slurm:
 
 ```
-python -m sample_factory.launcher.run --run=megaverse_rl.runs.single_agent --runner=slurm --slurm_workdir=./slurm_megaverse --experiment_suffix=slurm --slurm_gpus_per_job=1 --slurm_cpus_per_gpu=16 --slurm_sbatch_template=./sample_factory/launcher/slurm/sbatch_timeout.sh --pause_between=1 --slurm_print_only=False
+python -m sample_factory.launcher.run --run=megaverse_rl.runs.single_agent --backend=slurm --slurm_workdir=./slurm_megaverse --experiment_suffix=slurm --slurm_gpus_per_job=1 --slurm_cpus_per_gpu=16 --slurm_sbatch_template=./sample_factory/launcher/slurm/sbatch_timeout.sh --pause_between=1 --slurm_print_only=False
 ```
 
 

--- a/docs/environment-integrations/mujoco.md
+++ b/docs/environment-integrations/mujoco.md
@@ -10,29 +10,29 @@ pip install sample-factory[mujoco]
 
 ### Running Experiments
 
-Run MuJoCo experiments with the scripts in `sf_examples.mujoco_examples`. The default parameters have been chosen to match CleanRL's results in the report below.
+Run MuJoCo experiments with the scripts in `sf_examples.mujoco`. The default parameters have been chosen to match CleanRL's results in the report below.
 
 To train a model in the `Ant-v4` enviornment:
 
 ```
-python -m sf_examples.mujoco_examples.train_mujoco --algo=APPO --env=mujoco_ant --experiment=<experiment_name>
+python -m sf_examples.mujoco.train_mujoco --algo=APPO --env=mujoco_ant --experiment=<experiment_name>
 ```
 
 To visualize the training results, use the `enjoy_mujoco` script:
 
 ```
-python -m sf_examples.mujoco_examples.enjoy_mujoco --algo=APPO --env=mujoco_ant --experiment=<experiment_name>
+python -m sf_examples.mujoco.enjoy_mujoco --algo=APPO --env=mujoco_ant --experiment=<experiment_name>
 ```
 
 Multiple experiments can be run in parallel with the launcher module. `mujoco_all_envs` is an example launcher script that runs all mujoco envs with 10 seeds. 
 
 ```
-python -m sample_factory.launcher.run --run=sf_examples.mujoco_examples.experiments.mujoco_all_envs --backend=processes --max_parallel=4  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1 --experiment_suffix=0
+python -m sample_factory.launcher.run --run=sf_examples.mujoco.experiments.mujoco_all_envs --backend=processes --max_parallel=4  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1 --experiment_suffix=0
 ```
 
 #### List of Supported Environments
 
-Specify the environment to run with the `--env` command line parameter. The following MuJoCo v4 environments are supported out of the box, and more enviornments can be added as needed in `sf_examples.mujoco_examples.mujoco.mujoco_utils`
+Specify the environment to run with the `--env` command line parameter. The following MuJoCo v4 environments are supported out of the box, and more enviornments can be added as needed in `sf_examples.mujoco.mujoco.mujoco_utils`
 
 | MuJoCo Environment Name   | Sample-Factory Command Line Parameter |
 | ------------------------- | ------------------------------------- |

--- a/docs/environment-integrations/mujoco.md
+++ b/docs/environment-integrations/mujoco.md
@@ -24,10 +24,10 @@ To visualize the training results, use the `enjoy_mujoco` script:
 python -m sf_examples.mujoco_examples.enjoy_mujoco --algo=APPO --env=mujoco_ant --experiment=<experiment_name>
 ```
 
-Multiple experiments can be run in parallel with the runner module. `mujoco_all_envs` is an example runner script that runs all mujoco envs with 10 seeds. 
+Multiple experiments can be run in parallel with the launcher module. `mujoco_all_envs` is an example launcher script that runs all mujoco envs with 10 seeds. 
 
 ```
-python -m sample_factory.launcher.run --run=sf_examples.mujoco_examples.experiments.mujoco_all_envs --runner=processes --max_parallel=4  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1 --experiment_suffix=0
+python -m sample_factory.launcher.run --run=sf_examples.mujoco_examples.experiments.mujoco_all_envs --backend=processes --max_parallel=4  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1 --experiment_suffix=0
 ```
 
 #### List of Supported Environments

--- a/docs/environment-integrations/vizdoom.md
+++ b/docs/environment-integrations/vizdoom.md
@@ -23,7 +23,7 @@ Run at any point to visualize the experiment:
 python -m sf_examples.vizdoom.enjoy_vizdoom --env=doom_battle --algo=APPO --experiment=doom_battle_w20_v20
 ```
 
-Runner scripts are also provided in `sf_examples.vizdoom.experiments` to run experiments in parallel or on slurm.
+Launcher scripts are also provided in `sf_examples.vizdoom.experiments` to run experiments in parallel or on slurm.
 
 #### Reproducing Paper Results
 

--- a/docs/get-started/experiment-launcher.md
+++ b/docs/get-started/experiment-launcher.md
@@ -13,35 +13,35 @@ See [README](https://github.com/alex-petrenko/sample-factory#runner-interface) f
 
 ```
 Parallelize with local multiprocessing:
-$ python -m sample_factory.launcher.run --run=paper_doom_battle2_appo --runner=processes --max_parallel=4 --pause_between=10 --experiments_per_gpu=1 --num_gpus=4
+$ python -m sample_factory.launcher.run --run=paper_doom_battle2_appo --backend=processes --max_parallel=4 --pause_between=10 --experiments_per_gpu=1 --num_gpus=4
 
 Parallelize with Slurm:
-$ python -m sample_factory.launcher.run --run=megaverse_rl.runs.single_agent --runner=slurm --slurm_workdir=./megaverse_single_agent --experiment_suffix=slurm --pause_between=1 --slurm_gpus_per_job=1 --slurm_cpus_per_gpu=12 --slurm_sbatch_template=./megaverse_rl/slurm/sbatch_template.sh --slurm_print_only=False
+$ python -m sample_factory.launcher.run --run=megaverse_rl.runs.single_agent --backend=slurm --slurm_workdir=./megaverse_single_agent --experiment_suffix=slurm --pause_between=1 --slurm_gpus_per_job=1 --slurm_cpus_per_gpu=12 --slurm_sbatch_template=./megaverse_rl/slurm/sbatch_template.sh --slurm_print_only=False
 
 Parallelize with NGC (https://ngc.nvidia.com/):
-$ python -m sample_factory.launcher.run --run=rlgpu.run_scripts.dexterous_manipulation --runner=ngc --ngc_job_template=run_scripts/ngc_job_16g_1gpu.template --ngc_print_only=False --train_dir=/workspace/train_dir
+$ python -m sample_factory.launcher.run --run=rlgpu.run_scripts.dexterous_manipulation --backend=ngc --ngc_job_template=run_scripts/ngc_job_16g_1gpu.template --ngc_print_only=False --train_dir=/workspace/train_dir
 ```
 
 ##### All command-line options:
 ```
-usage: runner.py [-h] [--train_dir TRAIN_DIR] [--run RUN]
-                 [--runner {processes,slurm,ngc}]
-                 [--pause_between PAUSE_BETWEEN] [--num_gpus NUM_GPUS]
-                 [--experiments_per_gpu EXPERIMENTS_PER_GPU]
-                 [--max_parallel MAX_PARALLEL]
-                 [--experiment_suffix EXPERIMENT_SUFFIX]
+usage: run.py [-h] [--train_dir TRAIN_DIR] [--run RUN]
+              [--backend {processes,slurm,ngc}]
+              [--pause_between PAUSE_BETWEEN] [--num_gpus NUM_GPUS]
+              [--experiments_per_gpu EXPERIMENTS_PER_GPU]
+              [--max_parallel MAX_PARALLEL]
+              [--experiment_suffix EXPERIMENT_SUFFIX]
 
 # Slurm-related:
-                 [--slurm_gpus_per_job SLURM_GPUS_PER_JOB]
-                 [--slurm_cpus_per_gpu SLURM_CPUS_PER_GPU]
-                 [--slurm_print_only SLURM_PRINT_ONLY]
-                 [--slurm_workdir SLURM_WORKDIR]
-                 [--slurm_partition SLURM_PARTITION]
-                 [--slurm_sbatch_template SLURM_SBATCH_TEMPLATE]
+              [--slurm_gpus_per_job SLURM_GPUS_PER_JOB]
+              [--slurm_cpus_per_gpu SLURM_CPUS_PER_GPU]
+              [--slurm_print_only SLURM_PRINT_ONLY]
+              [--slurm_workdir SLURM_WORKDIR]
+              [--slurm_partition SLURM_PARTITION]
+              [--slurm_sbatch_template SLURM_SBATCH_TEMPLATE]
 
 # NGC-related
-                 [--ngc_job_template NGC_JOB_TEMPLATE]
-                 [--ngc_print_only NGC_PRINT_ONLY]
+              [--ngc_job_template NGC_JOB_TEMPLATE]
+              [--ngc_print_only NGC_PRINT_ONLY]
 ```
 
 ```
@@ -51,7 +51,7 @@ Arguments:
                         Directory for sub-experiments
   --run RUN             Name of the python module that describes the run, e.g.
                         sf_examples.vizdoom.experiments.doom_basic
-  --runner {processes,slurm,ngc}
+  --backend {processes,slurm,ngc}
   --pause_between PAUSE_BETWEEN
                         Pause in seconds between processes
   --num_gpus NUM_GPUS   How many GPUs to use (only for local multiprocessing)
@@ -71,7 +71,7 @@ Slurm-related:
   --slurm_print_only SLURM_PRINT_ONLY
                         Just print commands to the console without executing
   --slurm_workdir SLURM_WORKDIR
-                        Optional workdir. Used by slurm runner to store
+                        Optional workdir. Used by slurm launcher to store
                         logfiles etc.
   --slurm_partition SLURM_PARTITION
                         Adds slurm partition, i.e. for "gpu" it will add "-p
@@ -89,9 +89,9 @@ NGC-related:
 ```
 
 
-#### Runner script API
+#### Launcher script API
 
-A typical runner script:
+A typical launcher script:
 
 ```
 from sample_factory.launcher.run_description import RunDescription, Experiment, ParamGrid
@@ -111,7 +111,7 @@ _experiments = [
 RUN_DESCRIPTION = RunDescription('doom_basic_envs_appo', experiments=_experiments)
 ```
 
-Runner script should expose a RunDescription object named `RUN_DESCRIPTION` that contains a list of experiments to run and some auxiliary parameters.
+Launcher script should expose a RunDescription object named `RUN_DESCRIPTION` that contains a list of experiments to run and some auxiliary parameters.
 `RunDescription` parameter reference:
 
 ```
@@ -126,7 +126,7 @@ Runner script should expose a RunDescription object named `RUN_DESCRIPTION` that
         :param experiment_dirs_sf_format: adds an additional --experiments_root parameter, used only by SampleFactory.
                set to False for other applications.
         :param experiment_arg_name: CLI argument of the underlying experiment that determines it's unique name
-               to be generated by the runner. Default: --experiment
+               to be generated by the launcher. Default: --experiment
         :param experiment_dir_arg_name: CLI argument for the root train dir of your experiment. Default: --train_dir
         :param customize_experiment_name: whether to add a hyperparameter combination to the experiment name
         :param param_prefix: most experiments will use "--" prefix for each parameter, but some apps don't have this

--- a/docs/get-started/running-experiments.md
+++ b/docs/get-started/running-experiments.md
@@ -53,13 +53,13 @@ A total list of WandB settings:
 Once the experiment is started the link to the monitored session is going to be available in the logs (or by searching in Wandb Web console).
 
 
-### Runner interface
+### Launcher interface
 
 Sample Factory provides a simple interface that allows users to run experiments with multiple seeds
 (or hyperparameter searches) with optimal distribution of work across GPUs.
 The configuration of such experiments is done through Python scripts.
 
-Here's an example runner script that we used to train agents for 6 basic VizDoom environments with 10 seeds each:
+Here's an example launcher script that we used to train agents for 6 basic VizDoom environments with 10 seeds each:
 
 ```
 from sample_factory.launcher.run_description import RunDescription, Experiment, ParamGrid
@@ -89,12 +89,12 @@ When such a script is saved i.e. at `myproject/train_10_seeds.py` in your projec
 execute it:
 
 ```
-python -m sample_factory.launcher.run --run=myproject.train_10_seeds --runner=processes --max_parallel=12 --pause_between=10 --experiments_per_gpu=3 --num_gpus=4
+python -m sample_factory.launcher.run --run=myproject.train_10_seeds --backend=processes --max_parallel=12 --pause_between=10 --experiments_per_gpu=3 --num_gpus=4
 ``` 
 
 This will cycle through the requested configurations, training 12 experiments at the same time, 3 per GPU on 4 GPUs using local OS-level parallelism.
 
-Runner supports other backends for parallel execution: `--runner=slurm` and `--runner=ngc` for Slurm and NGC support respectively.
+Runner supports other backends for parallel execution: `--backend=slurm` and `--backend=ngc` for Slurm and NGC support respectively.
 
 Individual experiments will be stored in `train_dir/run_name` so the whole experiment can be easily monitored
 with a single Tensorboard command.

--- a/docs/get-started/running-slurm.md
+++ b/docs/get-started/running-slurm.md
@@ -1,4 +1,4 @@
-# How to use SF2 on Slurm
+# How to use Sample-Factory on Slurm
 
 This doc contains instructions for running Sample-Factory v2 using slurm
 
@@ -19,7 +19,7 @@ Install Miniconda
 
 Make new conda environment `conda create --name sf2` then `conda activate sf2`
 
-Download Sample-Factory and install dependencies for SF2
+Download Sample-Factory and install dependencies for Sample-Factory
 ```
 git clone https://github.com/alex-petrenko/sample-factory.git
 cd sample-factory
@@ -27,13 +27,13 @@ git checkout sf2
 pip install -e .
 ```
 
-### Necessary scripts in SF2
+### Necessary scripts in Sample-Factory
 
-To run a custom runner script for SF2 on slurm, you may need to write your own slurm_sbatch_template and/or runner script.
+To run a custom launcher script for Sample-Factory on slurm, you may need to write your own slurm_sbatch_template and/or launcher script.
 
-slurm_sbatch_template is a bash script that run by slurm before your python script. It includes commands to activate your conda environment etc. See an example at `./sample_factory/launcher/slurm/sbatch_template.sh`. Variables in the bash script can be added in `sample_factory.launcher.run_slurm`.
+slurm_sbatch_template is a bash script that run by slurm before your python script. It includes commands to activate your conda environment etc. See an example at `./sample_factory/launcher/slurm/sbatch_timeout.sh`. Variables in the bash script can be added in `sample_factory.launcher.run_slurm`.
 
-The runner script controls the python command slurm will run. Examples are located in `sf_examples`. You can run multiple experiments with different parameters using `ParamGrid`.
+The launcher script controls the python command slurm will run. Examples are located in `sf_examples`. You can run multiple experiments with different parameters using `ParamGrid`.
 
 #### Timeout Batch Script
 
@@ -41,7 +41,7 @@ If your slurm cluster has time limits for jobs, you can use the `sbatch_timeout.
 
 The time limit can be set with the `slurm_timeout` command line argument. It defaults to `0` which runs the job with no time limit. It is recommended the timeout be set to slightly less than the time limit of your job. For example, if the time limit is 24 hours, you should set `--slurm_timeout=23h`
 
-### Running runner scripts
+### Running launcher scripts
 
 Return to the login node with `exit`
 
@@ -49,9 +49,9 @@ Setup slurm output folder `mkdir sf2`
 
 Activate your conda environment with `bash` and `conda activate sf2` then `cd sample-factory`
 
-Run your runner script - an example mujuco runner (replace run, slurm_sbatch_template, and slurm_workdir with appropriate values)
+Run your launcher script - an example mujuco launcher (replace run, slurm_sbatch_template, and slurm_workdir with appropriate values)
 ```
-python -m sample_factory.launcher.run --runner=slurm --slurm_workdir=./slurm_mujoco --experiment_suffix=slurm --slurm_gpus_per_job=1 --slurm_cpus_per_gpu=16 --slurm_sbatch_template=./sample_factory/launcher/slurm/sbatch_timeout.sh --pause_between=1 --slurm_print_only=False --run=sf_examples.mujoco.experiments.mujoco_all_envs
+python -m sample_factory.launcher.run --backend=slurm --slurm_workdir=./slurm_mujoco --experiment_suffix=slurm --slurm_gpus_per_job=1 --slurm_cpus_per_gpu=16 --slurm_sbatch_template=./sample_factory/launcher/slurm/sbatch_timeout.sh --pause_between=1 --slurm_print_only=False --run=sf_examples.mujoco.experiments.mujoco_all_envs
 ```
 
 The `slurm_gpus_per_job` and `slurm_cpus_per_gpu` determine the resources allocated to each job. You can view the jobs without running them by setting `slurm_print_only=True`.

--- a/sample_factory/launcher/run_processes.py
+++ b/sample_factory/launcher/run_processes.py
@@ -19,7 +19,7 @@ def add_os_parallelism_args(parser: argparse.ArgumentParser) -> argparse.Argumen
         type=int,
         help="How many experiments can we squeeze on a single GPU. "
         "Specify this option if and only if you are using launcher to run several experiments using OS-level"
-        "parallelism (--launcher=processes)."
+        "parallelism (--backend=processes)."
         "In any other case use default value (-1) for not altering CUDA_VISIBLE_DEVICES at all."
         "This will allow your experiments to use all GPUs available (as many as --num_gpu allows)"
         "Helpful when e.g. you are running a single big PBT experiment.",

--- a/sf_examples/mujoco/README.md
+++ b/sf_examples/mujoco/README.md
@@ -8,8 +8,8 @@ or `pip install -e .[mujoco]` in the sample-factory directory.
 To run a single experiment, use the `sf_examples.mujoco.train_mujoco` script. An example command is
 `python -m sf_examples.mujoco.train_mujoco --algo=APPO --env=mujoco_ant --experiment=experiment_name`.
 
-To run multiple experiments in parallel, use the runner script at `sf_examples.mujoco.experiments.mujoco_all_envs`.
-An example command is `python -m sample_factory.launcher.run --run=sf_examples.mujoco.experiments.mujoco_all_envs --runner=processes --max_parallel=4  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1 --experiment_suffix=test`
+To run multiple experiments in parallel, use the launcher script at `sf_examples.mujoco.experiments.mujoco_all_envs`.
+An example command is `python -m sample_factory.launcher.run --run=sf_examples.mujoco.experiments.mujoco_all_envs --backend=processes --max_parallel=4  --pause_between=1 --experiments_per_gpu=10000 --num_gpus=1 --experiment_suffix=test`
 
 ## Showing Experiment Results
 


### PR DESCRIPTION
Docs fix to change runner to launcher and --runner to --backend
Also fixed some incorrect module names in mujoco docs, and changed SF2 to Sample-Factory in slurm docs