### PR TITLE
small bug in returning multi-agent enjoy

### DIFF
--- a/sample_factory/enjoy.py
+++ b/sample_factory/enjoy.py
@@ -266,4 +266,4 @@ def enjoy(cfg: Config) -> Tuple[StatusCode, float]:
         )
         push_to_hf(experiment_dir(cfg=cfg), cfg.hf_repository, cfg.num_policies)
 
-    return ExperimentStatus.SUCCESS, float(np.mean(episode_rewards))
+    return ExperimentStatus.SUCCESS, float(np.mean([np.mean(episode_rewards[i]) for i in range(env.num_agents)]))


### PR DESCRIPTION
IsaacGym AllegroHand throws an error when returning the mean rewards in enjoy: 
```
File "/home/andrewzhang/sample-factory/sample_factory/enjoy.py", line 269, in enjoy
    return ExperimentStatus.SUCCESS, float(np.mean(episode_rewards))
TypeError: only size-1 arrays can be converted to Python scalars
```
Seems like this happens if some agents do a different number of episodes than other agents.
I changed it to do the same thing as logging.