### PR TITLE
Changed hf hub integration to upload folder in one go

### DIFF
--- a/sample_factory/enjoy.py
+++ b/sample_factory/enjoy.py
@@ -264,6 +264,6 @@ def enjoy(cfg: Config) -> Tuple[StatusCode, float]:
         generate_model_card(
             experiment_dir(cfg=cfg), cfg.algo, cfg.env, cfg.hf_repository, reward_list, enjoy_name, cfg.train_script
         )
-        push_to_hf(experiment_dir(cfg=cfg), cfg.hf_repository, cfg.num_policies)
+        push_to_hf(experiment_dir(cfg=cfg), cfg.hf_repository)
 
     return ExperimentStatus.SUCCESS, float(np.mean([np.mean(episode_rewards[i]) for i in range(env.num_agents)]))

--- a/sample_factory/huggingface/huggingface_utils.py
+++ b/sample_factory/huggingface/huggingface_utils.py
@@ -110,34 +110,19 @@ Note, you may have to adjust `--train_for_env_steps` to a suitably high number a
     repocard.metadata_save(readme_path, metadata)
 
 
-def push_to_hf(dir_path: str, repo_name: str, num_policies: int = 1):
+def push_to_hf(dir_path: str, repo_name: str):
     repo_url = HfApi().create_repo(
         repo_id=repo_name,
         private=False,
         exist_ok=True,
     )
 
-    # Upload folders
-    folders = [".summary"]
-    for policy_id in range(num_policies):
-        folders.append(f"checkpoint_p{policy_id}")
-    for f in folders:
-        if os.path.exists(os.path.join(dir_path, f)):
-            upload_folder(
-                repo_id=repo_name,
-                folder_path=os.path.join(dir_path, f),
-                path_in_repo=f,
-            )
-
-    # Upload files
-    files = ["config.json", "README.md", "replay.mp4"]
-    for f in files:
-        if os.path.exists(os.path.join(dir_path, f)):
-            upload_file(
-                repo_id=repo_name,
-                path_or_fileobj=os.path.join(dir_path, f),
-                path_in_repo=f,
-            )
+    upload_folder(
+        repo_id=repo_name,
+        folder_path=dir_path,
+        path_in_repo=".",
+        ignore_patterns=[".git/*"],
+    )
 
     log.info(f"The model has been pushed to {repo_url}")
 

--- a/sample_factory/huggingface/push_to_hub.py
+++ b/sample_factory/huggingface/push_to_hub.py
@@ -19,12 +19,23 @@ def main():
     args = parser.parse_args()
 
     cfg_file = os.path.join(args.experiment_dir, "config.json")
+
+    if not os.path.isfile(cfg_file):
+        old_cfg_file = os.path.join(args.experiment_dir, "cfg.json")
+        if os.path.isfile(old_cfg_file):
+            os.rename(old_cfg_file, cfg_file)
+        else:
+            raise Exception(
+                f"Could not load saved parameters for experiment {args.experiment_dir} "
+                f"(file {cfg_file} not found). Check that you have the correct experiment directory."
+            )
+
     with open(cfg_file, "r") as json_file:
         json_params = json.load(json_file)
         cfg = AttrDict(json_params)
 
     generate_model_card(args.experiment_dir, cfg.algo, cfg.env, args.hf_repository)
-    push_to_hf(args.experiment_dir, args.hf_repository, cfg.num_policies)
+    push_to_hf(args.experiment_dir, args.hf_repository)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changed hub integration to upload entire experiment folder since there could be other environment specific files not accounted for in the `allow_patterns`. 
Added an `ignore_patterns` for the `.git` folder from the hf hub since that can cause issues when creating a new hf hub repo.
Rename cfg.json to config.json when using the `push_to_hub` script directly