### PR TITLE
Fixed bug when using mixed action spaces

### DIFF
--- a/sample_factory/algo/learning/learner.py
+++ b/sample_factory/algo/learning/learner.py
@@ -758,7 +758,7 @@ class Learner(Configurable):
 
                     kl_old_mean = float(kl_old.mean().item())
                     recent_kls.append(kl_old_mean)
-                    if kl_old.max().item() > 100:
+                    if kl_old.numel() > 0 and kl_old.max().item() > 100:
                         log.warning(f"KL-divergence is very high: {kl_old.max().item():.4f}")
 
                 # update the weights

--- a/sample_factory/algo/sampling/non_batched_sampling.py
+++ b/sample_factory/algo/sampling/non_batched_sampling.py
@@ -148,7 +148,9 @@ class ActorState:
             return self._process_action_space(actions, is_discrete=False)
         elif isinstance(self.env_info.action_space, gym.spaces.Tuple):
             out_actions = []
-            for split, space in zip(np.split(actions, self.env_info.action_splits), self.env_info.action_space):
+            for split, space in zip(
+                np.split(actions, np.cumsum(self.env_info.action_splits)), self.env_info.action_space
+            ):
                 is_discrete = isinstance(space, gym.spaces.Discrete)
                 out_actions.append(self._process_action_space(split, is_discrete))
             return out_actions

--- a/sample_factory/algo/sampling/non_batched_sampling.py
+++ b/sample_factory/algo/sampling/non_batched_sampling.py
@@ -149,7 +149,7 @@ class ActorState:
         elif isinstance(self.env_info.action_space, gym.spaces.Tuple):
             out_actions = []
             for split, space in zip(
-                np.split(actions, np.cumsum(self.env_info.action_splits)), self.env_info.action_space
+                np.split(actions, np.cumsum(self.env_info.action_splits)[:-1]), self.env_info.action_space
             ):
                 is_discrete = isinstance(space, gym.spaces.Discrete)
                 out_actions.append(self._process_action_space(split, is_discrete))


### PR DESCRIPTION
When using tuple action distributions in non-batched mode, there is a sneaky bug that appears. This is due to np.split and torch.split not having the same functionality. See: https://github.com/pytorch/pytorch/issues/50012

Fixed by using the cumsum of the action splits when in non batched mode,