### PR TITLE
[DOC] Fix incorrect call to register_model_core_factory

### DIFF
--- a/docs/03-customization/custom-models.md
+++ b/docs/03-customization/custom-models.md
@@ -91,7 +91,7 @@ def register_model_components():
 
     # or individual components
     global_model_factory().register_encoder_factory(CustomEncoder)
-    global_model_factory().register_core_factory(CustomCore)
+    global_model_factory().register_model_core_factory(CustomCore)
     global_model_factory().register_decoder_factory(CustomDecoder)
 
 def main():


### PR DESCRIPTION
Hello,

This PR fixes a small typo in the documentation about the call to the `def register_model_core_factory(self, make_model_core_func: MakeCoreFunc):` function of the `ModelFactory` class.

It only affects a single line of a documentation file.