### PR TITLE
Convert obs_space.keys() to list before `in` check

### DIFF
--- a/sf_examples/vizdoom/doom/doom_model.py
+++ b/sf_examples/vizdoom/doom/doom_model.py
@@ -17,7 +17,7 @@ class VizdoomEncoder(Encoder):
         self.encoder_out_size = self.basic_encoder.get_out_size()
 
         self.measurements_head = None
-        if "measurements" in obs_space.keys():
+        if "measurements" in list(obs_space.keys()):
             self.measurements_head = nn.Sequential(
                 nn.Linear(obs_space["measurements"].shape[0], 128),
                 nonlinearity(cfg),


### PR DESCRIPTION
I was having issues with a statement like this in my own codebase.  obs_space.keys() returns a view object apparently, and needs to be converted to a list for this condition to ever be satisfied.

If you check the debug logs when running the battle env, you'll see:
```
[2023-06-30 12:12:14,201][2413634] Conv encoder output size: 512
[2023-06-30 12:12:14,201][2413634] Policy head output size: 512
```

After this change you get:
```
[2023-06-30 12:13:13,133][2415262] Conv encoder output size: 512
[2023-06-30 12:13:13,134][2415262] Policy head output size: 640
```