### PR TITLE
Checking for vtrace before adding advantage stats to summary

### DIFF
--- a/sample_factory/algo/learning/learner.py
+++ b/sample_factory/algo/learning/learner.py
@@ -866,10 +866,13 @@ class Learner(Configurable):
         stats.act_min = var.mb.actions.min()
         stats.act_max = var.mb.actions.max()
 
-        stats.adv_min = var.mb.advantages.min()
-        stats.adv_max = var.mb.advantages.max()
-        stats.adv_std = var.adv_std
-        stats.adv_mean = var.adv_mean
+        if not self.cfg.with_vtrace:
+
+            stats.adv_min = var.mb.advantages.min()
+            stats.adv_max = var.mb.advantages.max()
+            stats.adv_std = var.adv_std
+            stats.adv_mean = var.adv_mean
+
         stats.max_abs_logprob = torch.abs(var.mb.action_logits).max()
 
         if hasattr(var.action_distribution, "summaries"):


### PR DESCRIPTION
So running simulations where `with_vtrace=True` currently crashes due to trying to load stats about the advantage function. Adding this check fixes it.

I'm not sure where this bug got introduced, because I've regularly used vtrace in the past. Also just FYI, in my simulations, I find that setting `with_vtrace=True` and `normalize_returns=False` yields better performance for feedforward networks, but RNNs more or less require GAE and normalized returns.