### PR TITLE
Add ONNX Model Export Support

### DIFF
--- a/.github/workflows/cover-ci.yml
+++ b/.github/workflows/cover-ci.yml
@@ -30,7 +30,7 @@ jobs:
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install conda env & dependencies
       run: |
-       pip install -e '.[atari, mujoco, envpool]'
+       pip install -e '.[atari, mujoco, envpool, onnx]'
        conda list
     - name: Install codecov dependencies
       run: |

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install conda env & dependencies
       run: |
        conda install python=${{ matrix.python-version }}
-       pip install -e '.[atari, mujoco, envpool, pettingzoo]'
+       pip install -e '.[atari, mujoco, envpool, pettingzoo, onnx]'
        conda list
     - name: Install test dependencies
       run: |

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Install conda env & dependencies
       run: |
        conda install python=${{ matrix.python-version }}
-       pip install -e '.[atari, mujoco, pettingzoo]'
+       pip install -e '.[atari, mujoco, pettingzoo, onnx]'
        conda list
     - name: Install test dependencies
       run: |

--- a/docs/03-customization/custom-environments.md
+++ b/docs/03-customization/custom-environments.md
@@ -121,6 +121,35 @@ if __name__ == "__main__":
 You can now run evaluation with `python enjoy_custom_env.py --env=custom_env_name --experiment=CustomEnv` to
 measure the performance of the trained model, visualize agent's performance, or record a video file.
 
+## ONNX export script template
+
+The exporting script is similar to the evaluation script, with a few key differences.
+It uses the `export_onnx` function to convert your model to ONNX format.
+
+```python3
+import sys
+
+from sample_factory.export_onnx import export_onnx
+from train_custom_env import parse_args, register_custom_env_envs
+
+
+def main():
+    """Script entry point."""
+    register_custom_env_envs()
+    cfg = parse_args(evaluation=True)
+
+    # The export_onnx function takes the configuration and the output file path
+    status = export_onnx(cfg, "my_model.onnx")
+
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+For information on how to use the exported ONNX models, please refer to the [Exporting a Model to ONNX](../07-advanced-topics/exporting-to-onnx.md) section.
+
 ## Examples
 
 * `sf_examples/train_custom_env_custom_model.py` - integrates an entirely custom toy environment.

--- a/docs/07-advanced-topics/exporting-to-onnx.md
+++ b/docs/07-advanced-topics/exporting-to-onnx.md
@@ -1,0 +1,75 @@
+# Exporting a Model to ONNX
+
+[ONNX](https://onnx.ai/) is a standard format for representing machine learning models. Sample Factory can export models to ONNX format.
+
+Exporting to ONNX allows you to:
+
+- Deploy your model in various production environments
+- Use hardware-specific optimizations provided by ONNX Runtime
+- Integrate your model with other tools and frameworks that support ONNX
+
+## Usage Examples
+
+First, train a model using Sample Factory.
+
+```bash
+python -m sf_examples.train_gym_env --experiment=example_gym_cartpole-v1 --env=CartPole-v1 --use_rnn=False --reward_scale=0.1
+```
+
+Then, use the following command to export it to ONNX:
+
+```bash
+python -m sf_examples.export_onnx_gym_env --experiment=example_gym_cartpole-v1 --env=CartPole-v1 --use_rnn=False
+```
+
+This creates `example_gym_cartpole-v1.onnx` in the current directory.
+
+### Using the Exported Model
+
+Here's how to use the exported ONNX model:
+
+```python
+import numpy as np
+import onnxruntime
+
+ort_session = onnxruntime.InferenceSession("example_gym_cartpole-v1.onnx", providers=["CPUExecutionProvider"])
+
+# The model expects a batch of observations as input.
+batch_size = 3
+ort_inputs = {"obs": np.random.rand(batch_size, 4).astype(np.float32)}
+
+ort_out = ort_session.run(None, ort_inputs)
+
+# The output is a list of actions, one for each observation in the batch.
+selected_actions = ort_out[0]
+print(selected_actions) # e.g. [1, 1, 0]
+```
+
+### RNN
+
+When exporting a model that uses RNN with `--use_rnn=True` (default), the model will expect RNN states as input.
+Note that for RNN models, the batch size must be 1.
+
+```python
+import numpy as np
+import onnxruntime
+
+ort_session = onnxruntime.InferenceSession("rnn.onnx", providers=["CPUExecutionProvider"])
+
+rnn_states_input = next(input for input in ort_session.get_inputs() if input.name == "rnn_states")
+rnn_states = np.zeros(rnn_states_input.shape, dtype=np.float32)
+batch_size = 1 # must be 1
+
+for _ in range(10):
+  ort_inputs = {"obs": np.random.rand(batch_size, 4).astype(np.float32), "rnn_states": rnn_states}
+  ort_out = ort_session.run(None, ort_inputs)
+  rnn_states = ort_out[1] # The second output is the updated rnn states
+```
+
+## Configuration
+
+The following key parameters will change the behavior of the exported mode:
+
+- `--use_rnn` Whether the model uses RNN. See the RNN example above.
+
+- `--eval_deterministic` If `True`, actions are selected by argmax.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,6 +157,7 @@ nav:
     - 07-advanced-topics/observer.md
     - 07-advanced-topics/profiling.md
     - 07-advanced-topics/action-masking.md
+    - 07-advanced-topics/exporting-to-onnx.md
   - Miscellaneous:
     - 08-miscellaneous/tests.md
     - 08-miscellaneous/v1-to-v2.md

--- a/sample_factory/algo/utils/action_distributions.py
+++ b/sample_factory/algo/utils/action_distributions.py
@@ -81,6 +81,18 @@ def argmax_actions(distribution):
         raise NotImplementedError(f"Action distribution type {type(distribution)} does not support argmax!")
 
 
+def action_probs(distribution):
+    if isinstance(distribution, TupleActionDistribution):
+        list_of_action_batches = [action_probs(d).squeeze(0) for d in distribution.distributions]
+        return torch.cat(list_of_action_batches)
+    elif hasattr(distribution, "probs"):
+        return distribution.probs
+    elif hasattr(distribution, "means"):
+        return distribution.means
+    else:
+        raise NotImplementedError(f"Action distribution type {type(distribution)} does not support argmax!")
+
+
 def masked_softmax(logits, mask):
     # Mask out the invalid logits by adding a large negative number (-1e9)
     logits = logits + (mask == 0) * -1e9

--- a/sample_factory/algo/utils/action_distributions.py
+++ b/sample_factory/algo/utils/action_distributions.py
@@ -81,18 +81,6 @@ def argmax_actions(distribution):
         raise NotImplementedError(f"Action distribution type {type(distribution)} does not support argmax!")
 
 
-def action_probs(distribution):
-    if isinstance(distribution, TupleActionDistribution):
-        list_of_action_batches = [action_probs(d).squeeze(0) for d in distribution.distributions]
-        return torch.cat(list_of_action_batches)
-    elif hasattr(distribution, "probs"):
-        return distribution.probs
-    elif hasattr(distribution, "means"):
-        return distribution.means
-    else:
-        raise NotImplementedError(f"Action distribution type {type(distribution)} does not support argmax!")
-
-
 def masked_softmax(logits, mask):
     # Mask out the invalid logits by adding a large negative number (-1e9)
     logits = logits + (mask == 0) * -1e9

--- a/sample_factory/export_onnx.py
+++ b/sample_factory/export_onnx.py
@@ -40,8 +40,9 @@ class OnnxExporter(nn.Module):
         else:
             rnn_states = generate_rnn_states(self.cfg)
 
+        action_mask = obs.pop("action_mask", None)
         normalized_obs = prepare_and_normalize_obs(self.actor_critic, obs)
-        policy_outputs = self.actor_critic(normalized_obs, rnn_states)
+        policy_outputs = self.actor_critic(normalized_obs, rnn_states, action_mask=action_mask)
         actions = policy_outputs["actions"]
         rnn_states = policy_outputs["new_rnn_states"]
 

--- a/sample_factory/export_onnx.py
+++ b/sample_factory/export_onnx.py
@@ -1,0 +1,192 @@
+import types
+
+import gymnasium as gym
+import torch
+import torch.nn as nn
+import torch.onnx
+from torch import Tensor
+
+from sample_factory.algo.learning.learner import Learner
+from sample_factory.algo.sampling.batched_sampling import preprocess_actions
+from sample_factory.algo.utils.action_distributions import argmax_actions
+from sample_factory.algo.utils.env_info import EnvInfo, extract_env_info
+from sample_factory.algo.utils.make_env import BatchedVecEnv
+from sample_factory.algo.utils.misc import ExperimentStatus
+from sample_factory.algo.utils.rl_utils import prepare_and_normalize_obs
+from sample_factory.algo.utils.tensor_utils import unsqueeze_tensor
+from sample_factory.cfg.arguments import load_from_checkpoint
+from sample_factory.enjoy import load_state_dict, make_env
+from sample_factory.model.actor_critic import ActorCritic, create_actor_critic
+from sample_factory.model.model_utils import get_rnn_size
+from sample_factory.utils.attr_dict import AttrDict
+from sample_factory.utils.typing import Config
+
+
+class OnnxExporter(nn.Module):
+    actor_critic: ActorCritic
+    cfg: Config
+    env_info: EnvInfo
+    rnn_states: Tensor
+
+    def __init__(self, cfg: Config, env_info: EnvInfo, actor_critic: ActorCritic):
+        super(OnnxExporter, self).__init__()
+        self.cfg = cfg
+        self.env_info = env_info
+        self.actor_critic = actor_critic
+
+    def forward(self, **obs):
+        if self.cfg.use_rnn:
+            rnn_states = obs.pop("rnn_states")
+        else:
+            rnn_states = generate_rnn_states(self.cfg)
+
+        normalized_obs = prepare_and_normalize_obs(self.actor_critic, obs)
+        policy_outputs = self.actor_critic(normalized_obs, rnn_states)
+        actions = policy_outputs["actions"]
+        rnn_states = policy_outputs["new_rnn_states"]
+
+        if self.cfg.eval_deterministic:
+            action_distribution = self.actor_critic.action_distribution()
+            actions = argmax_actions(action_distribution)
+
+        if actions.ndim == 1:
+            actions = unsqueeze_tensor(actions, dim=-1)
+
+        actions = preprocess_actions(self.env_info, actions, to_numpy=False)
+
+        if self.cfg.use_rnn:
+            return actions, rnn_states
+        else:
+            return actions
+
+
+def create_onnx_exporter(cfg: Config, env: BatchedVecEnv, enable_jit=False) -> OnnxExporter:
+    env_info = extract_env_info(env, cfg)
+    device = torch.device("cpu")
+
+    if enable_jit:
+        actor_critic = create_actor_critic(cfg, env.observation_space, env.action_space)
+    else:
+        try:
+            # HACK: disable torch.jit to avoid the following problem:
+            # https://github.com/pytorch/pytorch/issues/47887
+            #
+            # The other workaround is to use torch.jit.trace, but it requires
+            # to change many things of models too
+            torch.jit._state.disable()  # type: ignore[reportAttributeAccessIssue]
+            actor_critic = create_actor_critic(cfg, env.observation_space, env.action_space)
+        finally:
+            torch.jit._state.enable()  # type: ignore[reportAttributeAccessIssue]
+
+    actor_critic.eval()
+    actor_critic.model_to_device(device)
+    load_state_dict(cfg, actor_critic, device)
+
+    model = OnnxExporter(cfg, env_info, actor_critic)
+    return model
+
+
+def generate_args(space: gym.spaces.Space, batch_size: int = 1):
+    args = [unsqueeze_args(sample_space(space)) for _ in range(batch_size)]
+    args = [a for a in args if isinstance(a, dict)]
+    args = {k: torch.cat(tuple(a[k] for a in args), dim=0) for k in args[0].keys()} if len(args) > 0 else {}
+    return args
+
+
+def generate_rnn_states(cfg):
+    return torch.zeros([1, get_rnn_size(cfg)], dtype=torch.float32)
+
+
+def sample_space(space: gym.spaces.Space):
+    if isinstance(space, gym.spaces.Discrete):
+        return int(space.sample())
+    elif isinstance(space, gym.spaces.Box):
+        return torch.from_numpy(space.sample())
+    elif isinstance(space, gym.spaces.Dict):
+        return {k: sample_space(v) for k, v in space.spaces.items()}
+    elif isinstance(space, gym.spaces.Tuple):
+        return tuple(sample_space(s) for s in space.spaces)
+    else:
+        raise NotImplementedError(f"Unsupported space type: {type(space)}")
+
+
+def unsqueeze_args(args):
+    if isinstance(args, int):
+        return torch.tensor(args).unsqueeze(0)
+    if isinstance(args, torch.Tensor):
+        return args.unsqueeze(0)
+    if isinstance(args, dict):
+        return {k: unsqueeze_args(v) for k, v in args.items()}
+    elif isinstance(args, tuple):
+        return (unsqueeze_args(v) for v in args)
+    else:
+        raise NotImplementedError(f"Unsupported args type: {type(args)}")
+
+
+def create_forward(original_forward, arg_names: list[str]):
+    args_str = ", ".join(arg_names)
+
+    func_code = f"""
+def forward(self, {args_str}):
+    bound_args = locals()
+    bound_args.pop('self')
+    return original_forward(**bound_args)
+    """
+
+    globals_vars = {"original_forward": original_forward}
+    local_vars = {}
+    exec(func_code, globals_vars, local_vars)
+    return local_vars["forward"]
+
+
+def patch_forward(model: OnnxExporter, input_names: list[str]):
+    """
+    Patch the forward method of the model to dynamically define the input arguments
+    since *args and **kwargs are not supported in `torch.onnx.export`
+
+    see also: https://github.com/pytorch/pytorch/issues/96981 and https://github.com/pytorch/pytorch/issues/110439
+    """
+    forward = create_forward(model.forward, input_names)
+    model.forward = types.MethodType(forward, model)
+
+
+def export_onnx(cfg: Config, f: str) -> int:
+    cfg = load_from_checkpoint(cfg)
+    env = make_env(cfg)
+    model = create_onnx_exporter(cfg, env)
+    args = generate_args(env.observation_space)
+
+    # The args dict is mapped to the inputs of the model
+    # since usages of dictionaries is not recommended by pytorch
+    # see also: https://github.com/pytorch/pytorch/blob/v2.4.1/torch/onnx/utils.py#L768-L772
+    input_names = list(args.keys())
+
+    # Append the "output_" prefix to avoid name confliction with the input names
+    # that causes to add ".N" suffix to the input names.
+    # see also: https://discuss.pytorch.org/t/onnx-export-same-input-and-output-names/93155
+    output_names = ["output_actions"]
+
+    if cfg.use_rnn:
+        input_names.append("rnn_states")
+        output_names.append("output_rnn_states")
+        args["rnn_states"] = generate_rnn_states(cfg)
+
+        # batch size must be 1 when rnn is used
+        # See also https://github.com/onnx/onnx/issues/3182
+        dynamic_axes = None
+    else:
+        dynamic_axes = {key: {0: "batch_size"} for key in input_names + output_names}
+
+    patch_forward(model, input_names)
+
+    torch.onnx.export(
+        model,
+        (args,),
+        f,
+        export_params=True,
+        input_names=input_names,
+        output_names=output_names,
+        dynamic_axes=dynamic_axes,
+    )
+
+    return ExperimentStatus.SUCCESS

--- a/sample_factory/export_onnx.py
+++ b/sample_factory/export_onnx.py
@@ -9,7 +9,7 @@ from torch import Tensor
 
 from sample_factory.algo.learning.learner import Learner
 from sample_factory.algo.sampling.batched_sampling import preprocess_actions
-from sample_factory.algo.utils.action_distributions import action_probs, argmax_actions
+from sample_factory.algo.utils.action_distributions import argmax_actions
 from sample_factory.algo.utils.env_info import EnvInfo, extract_env_info
 from sample_factory.algo.utils.make_env import BatchedVecEnv
 from sample_factory.algo.utils.misc import ExperimentStatus
@@ -50,9 +50,6 @@ class OnnxExporter(nn.Module):
         if self.cfg.eval_deterministic:
             action_distribution = self.actor_critic.action_distribution()
             actions = argmax_actions(action_distribution)
-            probs = action_probs(action_distribution)
-        else:
-            probs = torch.zeros(0)
 
         if actions.ndim == 1:
             actions = unsqueeze_tensor(actions, dim=-1)
@@ -60,9 +57,9 @@ class OnnxExporter(nn.Module):
         actions = preprocess_actions(self.env_info, actions, to_numpy=False)
 
         if self.cfg.use_rnn:
-            return actions, rnn_states, probs
+            return actions, rnn_states
         else:
-            return actions, probs
+            return actions
 
 
 def create_onnx_exporter(cfg: Config, env: BatchedVecEnv, enable_jit=False) -> OnnxExporter:

--- a/sample_factory/export_onnx.py
+++ b/sample_factory/export_onnx.py
@@ -1,4 +1,5 @@
 import types
+from typing import List
 
 import gymnasium as gym
 import torch
@@ -124,7 +125,7 @@ def unsqueeze_args(args):
         raise NotImplementedError(f"Unsupported args type: {type(args)}")
 
 
-def create_forward(original_forward, arg_names: list[str]):
+def create_forward(original_forward, arg_names: List[str]):
     args_str = ", ".join(arg_names)
 
     func_code = f"""
@@ -140,7 +141,7 @@ def forward(self, {args_str}):
     return local_vars["forward"]
 
 
-def patch_forward(model: OnnxExporter, input_names: list[str]):
+def patch_forward(model: OnnxExporter, input_names: List[str]):
     """
     Patch the forward method of the model to dynamically define the input arguments
     since *args and **kwargs are not supported in `torch.onnx.export`

--- a/sample_factory/export_onnx.py
+++ b/sample_factory/export_onnx.py
@@ -9,7 +9,7 @@ from torch import Tensor
 
 from sample_factory.algo.learning.learner import Learner
 from sample_factory.algo.sampling.batched_sampling import preprocess_actions
-from sample_factory.algo.utils.action_distributions import argmax_actions
+from sample_factory.algo.utils.action_distributions import action_probs, argmax_actions
 from sample_factory.algo.utils.env_info import EnvInfo, extract_env_info
 from sample_factory.algo.utils.make_env import BatchedVecEnv
 from sample_factory.algo.utils.misc import ExperimentStatus
@@ -50,6 +50,9 @@ class OnnxExporter(nn.Module):
         if self.cfg.eval_deterministic:
             action_distribution = self.actor_critic.action_distribution()
             actions = argmax_actions(action_distribution)
+            probs = action_probs(action_distribution)
+        else:
+            probs = torch.zeros(0)
 
         if actions.ndim == 1:
             actions = unsqueeze_tensor(actions, dim=-1)
@@ -57,9 +60,9 @@ class OnnxExporter(nn.Module):
         actions = preprocess_actions(self.env_info, actions, to_numpy=False)
 
         if self.cfg.use_rnn:
-            return actions, rnn_states
+            return actions, rnn_states, probs
         else:
-            return actions
+            return actions, probs
 
 
 def create_onnx_exporter(cfg: Config, env: BatchedVecEnv, enable_jit=False) -> OnnxExporter:

--- a/setup.py
+++ b/setup.py
@@ -83,8 +83,8 @@ setup(
         + _docs_deps
         + _atari_deps
         + _mujoco_deps
-        + _onnx_deps,
-        + _pettingzoo_deps
+        + _onnx_deps
+        + _pettingzoo_deps,
         "atari": _atari_deps,
         "envpool": _envpool_deps,
         "mujoco": _mujoco_deps,

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ _nethack_deps = [
 ]
 _envpool_deps = ["envpool"]
 _pettingzoo_deps = ["pettingzoo[classic]"]
+_onnx_deps = ["onnx", "onnxruntime"]
 
 _docs_deps = [
     "mkdocs-material",
@@ -82,11 +83,13 @@ setup(
         + _docs_deps
         + _atari_deps
         + _mujoco_deps
-        + _pettingzoo_deps,
+        + _onnx_deps,
+        + _pettingzoo_deps
         "atari": _atari_deps,
         "envpool": _envpool_deps,
         "mujoco": _mujoco_deps,
         "nethack": _nethack_deps,
+        "onnx": _onnx_deps,
         "pettingzoo": _pettingzoo_deps,
         "vizdoom": ["vizdoom<2.0", "gymnasium[classic_control]"],
         # "dmlab": ["dm_env"],  <-- these are just auxiliary packages, the main package has to be built from sources

--- a/sf_examples/export_onnx_gym_env.py
+++ b/sf_examples/export_onnx_gym_env.py
@@ -1,0 +1,23 @@
+"""
+An example that shows how to export a SampleFactory model to the ONNX format.
+
+Example command line for CartPole-v1 that exports to "./example_gym_cartpole-v1.onnx"
+python -m sf_examples.export_onnx_gym_env --experiment=example_gym_cartpole-v1 --env=CartPole-v1 --use_rnn=False
+
+"""
+
+import sys
+
+from sample_factory.export_onnx import export_onnx
+from sf_examples.train_gym_env import parse_custom_args, register_custom_components
+
+
+def main():
+    register_custom_components()
+    cfg = parse_custom_args(evaluation=True)
+    status = export_onnx(cfg, f"{cfg.experiment}.onnx")
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/envs/tuple_action_envs/test_two_discrete_action_dist_env_batched.py
+++ b/tests/envs/tuple_action_envs/test_two_discrete_action_dist_env_batched.py
@@ -9,6 +9,7 @@ from sample_factory.cfg.arguments import parse_full_cfg, parse_sf_args
 from sample_factory.envs.env_utils import register_env
 from sample_factory.train import run_rl
 from tests.envs.tuple_action_envs.test_two_discrete_action_dist_env_non_batched import DiscreteActions, get_reward
+from tests.export_onnx_utils import check_export_onnx
 
 
 class IdentityEnvTwoDiscreteActions(gym.Env):
@@ -118,6 +119,13 @@ def register_test_components():
     )
 
 
+def parse_args(argv=None, evaluation=False):
+    parser, cfg = parse_sf_args(argv=argv, evaluation=evaluation)
+    override_defaults(parser)
+    cfg = parse_full_cfg(parser, argv=argv)
+    return cfg
+
+
 def test_batched_two_discrete_action_dists():
     """Script entry point."""
     register_test_components()
@@ -128,10 +136,9 @@ def test_batched_two_discrete_action_dists():
         "--restart_behavior=overwrite",
         "--device=cpu",
     ]
-    parser, cfg = parse_sf_args(argv=argv)
-
-    override_defaults(parser)
-    cfg = parse_full_cfg(parser, argv=argv)
-
+    cfg = parse_args(argv=argv)
     status = run_rl(cfg)
+
+    cfg = parse_args(argv=argv, evaluation=True)
+    check_export_onnx(cfg)
     return status

--- a/tests/envs/tuple_action_envs/test_two_discrete_action_dist_env_non_batched.py
+++ b/tests/envs/tuple_action_envs/test_two_discrete_action_dist_env_non_batched.py
@@ -9,6 +9,7 @@ from sample_factory.cfg.arguments import parse_full_cfg, parse_sf_args
 from sample_factory.envs.env_utils import register_env
 from sample_factory.train import run_rl
 from sample_factory.utils.utils import debug_log_every_n
+from tests.export_onnx_utils import check_export_onnx
 
 DiscreteActions = Union[List[int], Tuple[int, ...], np.ndarray]
 
@@ -85,6 +86,13 @@ def register_test_components():
     )
 
 
+def parse_args(argv=None, evaluation=False):
+    parser, cfg = parse_sf_args(argv=argv, evaluation=evaluation)
+    override_defaults(parser)
+    cfg = parse_full_cfg(parser, argv=argv)
+    return cfg
+
+
 def test_non_batched_two_discrete_action_dists():
     """Script entry point."""
     register_test_components()
@@ -97,9 +105,9 @@ def test_non_batched_two_discrete_action_dists():
         "--device=cpu",
     ]
 
-    parser, cfg = parse_sf_args(argv=argv)
-    override_defaults(parser)
-    cfg = parse_full_cfg(parser, argv=argv)
-
+    cfg = parse_args(argv=argv)
     status = run_rl(cfg)
+
+    cfg = parse_args(argv=argv, evaluation=True)
+    check_export_onnx(cfg)
     return status

--- a/tests/export_onnx_utils.py
+++ b/tests/export_onnx_utils.py
@@ -1,3 +1,4 @@
+import numpy as np
 import onnx
 import onnxruntime
 import torch
@@ -27,26 +28,34 @@ def check_rnn_inference_result(
 
     for _ in range(3):
         args = generate_args(env.observation_space)
-        torch_out, rnn_states = model(**args, rnn_states=rnn_states)
+        actions, rnn_states, probs = model(**args, rnn_states=rnn_states)
 
         ort_inputs = {k: to_numpy(v) for k, v in args.items()}
         ort_inputs["rnn_states"] = ort_rnn_states
         ort_out = ort_session.run(None, ort_inputs)
         ort_rnn_states = ort_out[1]
 
-        assert (to_numpy(torch_out[0]) == ort_out[0]).all()
+        max_prob_diff = np.abs(to_numpy(probs) - ort_out[2]).max()
+        print(f"max_prob_diff={max_prob_diff:.10f}")
+        print(f"torch probs={to_numpy(probs)}")
+        print(f"ort probs={ort_out[2]}")
+        assert (to_numpy(actions) == ort_out[0]).all()
 
 
 def check_inference_result(env: BatchedVecEnv, model: OnnxExporter, ort_session: onnxruntime.InferenceSession) -> None:
     for batch_size in [1, 3]:
         args = generate_args(env.observation_space, batch_size)
-        torch_out = model(**args)
+        actions, probs = model(**args)
 
         ort_inputs = {k: to_numpy(v) for k, v in args.items()}
         ort_out = ort_session.run(None, ort_inputs)
 
+        max_prob_diff = np.abs(to_numpy(probs) - ort_out[1]).max()
+        print(f"max_prob_diff={max_prob_diff:.10f}")
+        print(f"torch probs={to_numpy(probs)}")
+        print(f"ort probs={ort_out[1]}")
         assert len(ort_out[0]) == batch_size
-        assert (to_numpy(torch_out[0]) == ort_out[0]).all()
+        assert (to_numpy(actions) == ort_out[0]).all()
 
 
 def check_export_onnx(cfg: Config) -> None:

--- a/tests/export_onnx_utils.py
+++ b/tests/export_onnx_utils.py
@@ -27,26 +27,26 @@ def check_rnn_inference_result(
 
     for _ in range(3):
         args = generate_args(env.observation_space)
-        torch_out, rnn_states = model(**args, rnn_states=rnn_states)
+        actions, rnn_states = model(**args, rnn_states=rnn_states)
 
         ort_inputs = {k: to_numpy(v) for k, v in args.items()}
         ort_inputs["rnn_states"] = ort_rnn_states
         ort_out = ort_session.run(None, ort_inputs)
         ort_rnn_states = ort_out[1]
 
-        assert (to_numpy(torch_out[0]) == ort_out[0]).all()
+        assert (to_numpy(actions) == ort_out[0]).all()
 
 
 def check_inference_result(env: BatchedVecEnv, model: OnnxExporter, ort_session: onnxruntime.InferenceSession) -> None:
     for batch_size in [1, 3]:
         args = generate_args(env.observation_space, batch_size)
-        torch_out = model(**args)
+        actions = model(**args)
 
         ort_inputs = {k: to_numpy(v) for k, v in args.items()}
         ort_out = ort_session.run(None, ort_inputs)
 
         assert len(ort_out[0]) == batch_size
-        assert (to_numpy(torch_out[0]) == ort_out[0]).all()
+        assert (to_numpy(actions) == ort_out[0]).all()
 
 
 def check_export_onnx(cfg: Config) -> None:

--- a/tests/export_onnx_utils.py
+++ b/tests/export_onnx_utils.py
@@ -1,0 +1,68 @@
+import onnx
+import onnxruntime
+import torch
+
+from sample_factory.algo.utils.make_env import BatchedVecEnv
+from sample_factory.enjoy import make_env
+from sample_factory.export_onnx import OnnxExporter, create_onnx_exporter, export_onnx, generate_args
+from sample_factory.utils.typing import Config
+from sample_factory.utils.utils import experiment_dir
+
+
+def to_numpy(tensor: torch.Tensor):
+    return tensor.detach().cpu().numpy() if tensor.requires_grad else tensor.cpu().numpy()
+
+
+def check_onnx_model(filename: str) -> None:
+    model = onnx.load(filename)
+    onnx.checker.check_model(model)
+
+
+def check_rnn_inference_result(
+    env: BatchedVecEnv, model: OnnxExporter, ort_session: onnxruntime.InferenceSession
+) -> None:
+    rnn_states_input = next(input for input in ort_session.get_inputs() if input.name == "rnn_states")
+    rnn_states = torch.zeros(rnn_states_input.shape, dtype=torch.float32)
+    ort_rnn_states = to_numpy(rnn_states)
+
+    for _ in range(3):
+        args = generate_args(env.observation_space)
+        torch_out, rnn_states = model(**args, rnn_states=rnn_states)
+
+        ort_inputs = {k: to_numpy(v) for k, v in args.items()}
+        ort_inputs["rnn_states"] = ort_rnn_states
+        ort_out = ort_session.run(None, ort_inputs)
+        ort_rnn_states = ort_out[1]
+
+        assert (to_numpy(torch_out[0]) == ort_out[0]).all()
+
+
+def check_inference_result(env: BatchedVecEnv, model: OnnxExporter, ort_session: onnxruntime.InferenceSession) -> None:
+    for batch_size in [1, 3]:
+        args = generate_args(env.observation_space, batch_size)
+        torch_out = model(**args)
+
+        ort_inputs = {k: to_numpy(v) for k, v in args.items()}
+        ort_out = ort_session.run(None, ort_inputs)
+
+        assert len(ort_out[0]) == batch_size
+        assert (to_numpy(torch_out[0]) == ort_out[0]).all()
+
+
+def check_export_onnx(cfg: Config) -> None:
+    cfg.eval_deterministic = True
+    directory = experiment_dir(cfg=cfg, mkdir=False)
+    filename = f"{directory}/{cfg.experiment}.onnx"
+    status = export_onnx(cfg, filename)
+    assert status == 0
+
+    check_onnx_model(filename)
+
+    env = make_env(cfg)
+    model = create_onnx_exporter(cfg, env, enable_jit=True)
+    ort_session = onnxruntime.InferenceSession(filename, providers=["CPUExecutionProvider"])
+
+    if cfg.use_rnn:
+        check_rnn_inference_result(env, model, ort_session)
+    else:
+        check_inference_result(env, model, ort_session)


### PR DESCRIPTION
This PR introduces support for exporting trained models to the ONNX format in Sample Factory. The feature will be useful in many cases, including for people who want to use their trained models on a different platform or language. It's nice to build the functionality into Sample Factory, since usually, the underlying architecture is something that users don't need to know about.

It's implemented using [TorchScript-based ONNX Exporter](https://pytorch.org/docs/stable/onnx_torchscript.html) for now. I tried [TorchDynamo](https://pytorch.org/docs/stable/onnx_dynamo.html) as well but couldn’t get it to work. 
The usage is described in the added documentation.