### PR TITLE
Log env_steps in wandb

### DIFF
--- a/sample_factory/algo/learning/learner.py
+++ b/sample_factory/algo/learning/learner.py
@@ -843,6 +843,7 @@ class Learner(Configurable):
         self.last_summary_time = time.time()
         stats = AttrDict()
 
+        stats.env_steps = self.env_steps
         stats.lr = self.curr_lr
         stats.actual_lr = train_loop_vars.actual_lr  # potentially scaled because of masked data
 

--- a/sample_factory/utils/wandb_utils.py
+++ b/sample_factory/utils/wandb_utils.py
@@ -55,6 +55,14 @@ def init_wandb(cfg):
 
     wandb.config.update(cfg, allow_val_change=True)
 
+    wandb.define_metric("train/env_steps")
+    wandb.define_metric("train/*", step_metric="train/env_steps")
+    wandb.define_metric("perf/*", step_metric="train/env_steps")
+    wandb.define_metric("len/*", step_metric="train/env_steps")
+    wandb.define_metric("policy_stats/*", step_metric="train/env_steps")
+    wandb.define_metric("reward/*", step_metric="train/env_steps")
+    wandb.define_metric("stats/*", step_metric="train/env_steps")
+
 
 def finish_wandb(cfg):
     if cfg.with_wandb:


### PR DESCRIPTION
This PR adds metric definitions for Weights & Biases logging to better organize and visualize training metrics. Now we have an option to use `env_steps` in X axis. 