### PR TITLE
Feature: add wandb dir as parser argument

### DIFF
--- a/sample_factory/cfg/cfg.py
+++ b/sample_factory/cfg/cfg.py
@@ -744,6 +744,13 @@ def add_wandb_args(p: ArgumentParser):
         nargs="*",
         help="Tags can help with finding experiments in WandB web console",
     )
+    p.add_argument(
+        "--wandb_dir",
+        default="wandb",
+        type=str,
+        nargs="*",
+        help="Logging Directory for WandB",
+    )
 
 
 def add_pbt_args(p: ArgumentParser):

--- a/sample_factory/cfg/cfg.py
+++ b/sample_factory/cfg/cfg.py
@@ -746,9 +746,8 @@ def add_wandb_args(p: ArgumentParser):
     )
     p.add_argument(
         "--wandb_dir",
-        default="wandb",
+        default=join(os.getcwd(), "wandb"),
         type=str,
-        nargs="*",
         help="Logging Directory for WandB",
     )
 

--- a/sample_factory/utils/utils.py
+++ b/sample_factory/utils/utils.py
@@ -402,6 +402,10 @@ def experiments_dir(cfg, mkdir=True) -> str:
     return maybe_ensure_dir_exists(cfg.train_dir, mkdir)
 
 
+def wandb_dir(cfg, mkdir=True) -> str:
+    return maybe_ensure_dir_exists(cfg.wandb_dir, mkdir)
+
+
 def experiment_dir(cfg, mkdir=True) -> str:
     experiment = cfg.experiment
     experiments_root = experiments_dir(cfg, mkdir)

--- a/sample_factory/utils/wandb_utils.py
+++ b/sample_factory/utils/wandb_utils.py
@@ -44,6 +44,7 @@ def init_wandb(cfg):
             tags=cfg.wandb_tags,
             resume="allow",
             settings=wandb.Settings(start_method="fork"),
+            dir=cfg.wandb_dir,
         )
 
     log.debug("Initializing WandB...")

--- a/sample_factory/utils/wandb_utils.py
+++ b/sample_factory/utils/wandb_utils.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sample_factory.utils.utils import log, retry
+from sample_factory.utils.utils import log, retry, wandb_dir
 
 
 def init_wandb(cfg):
@@ -44,7 +44,7 @@ def init_wandb(cfg):
             tags=cfg.wandb_tags,
             resume="allow",
             settings=wandb.Settings(start_method="fork"),
-            dir=cfg.wandb_dir,
+            dir=wandb_dir(cfg, True),
         )
 
     log.debug("Initializing WandB...")


### PR DESCRIPTION
Adds the possibility to change the wandb directory.
Default behaviour (when not setting it) should be the same as before.