### PR TITLE
train_for_seconds flag not being tracked

### DIFF
--- a/sample_factory/algo/runners/runner.py
+++ b/sample_factory/algo/runners/runner.py
@@ -678,6 +678,7 @@ class Runner(EventLoopObject, Configurable):
         self._observers_call(AlgoObserver.on_connect_components, self)
 
     def _should_end_training(self):
+        self.total_train_seconds = time.time() - self.start_time
         end = len(self.env_steps) > 0 and all(s > self.cfg.train_for_env_steps for s in self.env_steps.values())
         end |= self.total_train_seconds > self.cfg.train_for_seconds
         return end


### PR DESCRIPTION
This is a small PR, previously `train_for_seconds` flag was not being tracked (as `total_train_seconds` was not calculated), and as a result training didn't stop as set by `train_for_seconds`.

I believe this was a minor overlook, thus I didn't open an issue but open a PR directly. 