### PR TITLE
Fix advantage summaries never being logged in _record_summaries

### DIFF
--- a/sample_factory/algo/learning/learner.py
+++ b/sample_factory/algo/learning/learner.py
@@ -870,7 +870,7 @@ class Learner(Configurable):
         stats.act_min = var.mb.actions.min()
         stats.act_max = var.mb.actions.max()
 
-        if "adv_mean" in stats:
+        if "advantages" in var.mb:
             stats.adv_min = var.mb.advantages.min()
             stats.adv_max = var.mb.advantages.max()
             stats.adv_std = var.adv_std

--- a/sample_factory/algo/sampling/rollout_worker.py
+++ b/sample_factory/algo/sampling/rollout_worker.py
@@ -61,7 +61,12 @@ def init_rollout_worker_process(sf_context: SampleFactoryContext, worker: Rollou
         set_process_cpu_affinity(worker.worker_idx, cfg.num_workers)
 
     if cfg.num_workers > 1:
-        psutil.Process().nice(min(cfg.default_niceness + 10, 20))
+        # renicing can fail (AccessDenied) on restricted nodes (SLURM cgroups /
+        # shared local nodes); it is best-effort and must never kill the worker.
+        try:
+            psutil.Process().nice(min(cfg.default_niceness + 10, 20))
+        except (psutil.AccessDenied, PermissionError) as e:
+            log.warning("Unable to set rollout worker niceness (continuing): %s", e)
         torch.set_num_threads(1)
 
     if cfg.actor_worker_gpus:


### PR DESCRIPTION
PR https://github.com/alex-petrenko/sample-factory/pull/286 guarded the advantage-stat logging with `if "adv_mean" in stats:` to avoid the V-trace
  AttributeError on `var.mb.advantages` (which exists only on the GAE path). But
  `adv_mean` is only ever added to `stats` *inside* that block, so the condition
  is always False: the fix is dead code and adv_min/max/std/mean are now never
  logged under any config.
  
  Guard on the value that's actually conditional instead:
  
      if "advantages" in var.mb:
          stats.adv_min = var.mb.advantages.min()
          stats.adv_max = var.mb.advantages.max()
          stats.adv_std = var.adv_std
          stats.adv_mean = var.adv_mean

  GAE -> logged; V-trace -> skipped, no crash. Verified on CartPole both paths.
  (`if "adv_mean" in var:` would be wrong too — it's always True and re-crashes.)